### PR TITLE
fix: harden Windows setup script for reliable first-run completion

### DIFF
--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -1,8 +1,46 @@
 # Windows Development Environment Setup Script for Cooper
-# This script installs all prerequisites needed to build and run the app on Windows
+# This script installs all prerequisites needed to build and run the app on Windows.
+# Designed to complete fully on the first run with no terminal restart required.
 
 Write-Host "=== Cooper - Windows Setup ===" -ForegroundColor Cyan
 Write-Host ""
+
+# --- Helpers ---
+
+function Refresh-Path {
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+}
+
+# Locate a real Python binary, skipping the Windows Store alias under WindowsApps.
+function Find-Python {
+    # 1. Check common install locations directly
+    $candidates = @(
+        "$env:LOCALAPPDATA\Programs\Python\Python3*\python.exe",
+        "C:\Python3*\python.exe",
+        "C:\Program Files\Python3*\python.exe",
+        "C:\Program Files (x86)\Python3*\python.exe"
+    )
+    foreach ($glob in $candidates) {
+        $found = Get-ChildItem $glob -ErrorAction SilentlyContinue | Sort-Object FullName -Descending | Select-Object -First 1
+        if ($found) { return $found.FullName }
+    }
+    # 2. Walk PATH entries, but skip WindowsApps aliases
+    foreach ($dir in ($env:Path -split ';')) {
+        if ($dir -match 'WindowsApps') { continue }
+        $exe = Join-Path $dir "python.exe"
+        if (Test-Path $exe) { return $exe }
+    }
+    return $null
+}
+
+# Locate node.exe on PATH.
+function Find-Node {
+    foreach ($dir in ($env:Path -split ';')) {
+        $exe = Join-Path $dir "node.exe"
+        if (Test-Path $exe) { return $exe }
+    }
+    return $null
+}
 
 # Check if running as Administrator (optional but recommended)
 $isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
@@ -31,64 +69,106 @@ try {
     Write-Host "✗ Failed to set execution policy: $_" -ForegroundColor Red
 }
 
-# Install Node.js if needed
+# --- Node.js ---
 Write-Host ""
 Write-Host "Checking Node.js..." -ForegroundColor Yellow
-try {
-    $nodeVersion = node --version
-    $nodeMajor = [int]($nodeVersion -replace 'v(\d+)\..*', '$1')
-    if ($nodeMajor -ge 22) {
-        Write-Host "✓ Node.js $nodeVersion (sufficient)" -ForegroundColor Green
-    } else {
-        Write-Host "✗ Node.js $nodeVersion found, but version 22+ required" -ForegroundColor Red
-        Write-Host "Installing Node.js 22..." -ForegroundColor Yellow
-        winget install OpenJS.NodeJS.LTS --silent
-        Write-Host "✓ Node.js installed. Please restart your terminal." -ForegroundColor Green
+Refresh-Path
+$nodeOk = $false
+$nodePath = Find-Node
+if ($nodePath) {
+    $nodeVersion = & $nodePath --version 2>&1
+    if ($LASTEXITCODE -eq 0 -and $nodeVersion -match '^v(\d+)') {
+        if ([int]$Matches[1] -ge 22) {
+            $nodeOk = $true
+            Write-Host "✓ Node.js $nodeVersion (sufficient)" -ForegroundColor Green
+        } else {
+            Write-Host "✗ Node.js $nodeVersion found, but version 22+ required" -ForegroundColor Red
+        }
     }
-} catch {
-    Write-Host "Node.js not found. Installing..." -ForegroundColor Yellow
-    winget install OpenJS.NodeJS.LTS --silent
-    Write-Host "✓ Node.js installed. Please restart your terminal." -ForegroundColor Green
+}
+if (-not $nodeOk) {
+    Write-Host "Installing Node.js LTS..." -ForegroundColor Yellow
+    winget install OpenJS.NodeJS.LTS --silent --accept-package-agreements --accept-source-agreements
+    Refresh-Path
+    $nodePath = Find-Node
+    if (-not $nodePath) {
+        Write-Host "✗ Node.js installation failed — 'node.exe' not found on PATH." -ForegroundColor Red
+        exit 1
+    }
+    # Prepend so this session can use it even if PATH ordering is odd
+    $env:Path = (Split-Path $nodePath) + ";" + $env:Path
+    $nodeVersion = & $nodePath --version 2>&1
+    Write-Host "✓ Node.js $nodeVersion installed" -ForegroundColor Green
 }
 
-# Install Python if needed
+# --- Python (required by node-gyp for native modules) ---
 Write-Host ""
 Write-Host "Checking Python..." -ForegroundColor Yellow
-try {
-    python --version | Out-Null
-    Write-Host "✓ Python is installed" -ForegroundColor Green
-} catch {
+Refresh-Path
+$pythonPath = Find-Python
+if (-not $pythonPath) {
     Write-Host "Python not found. Installing Python 3.12..." -ForegroundColor Yellow
-    winget install Python.Python.3.12 --silent
-    Write-Host "✓ Python installed. Please restart your terminal." -ForegroundColor Green
+    winget install Python.Python.3.12 --silent --accept-package-agreements --accept-source-agreements
+    Refresh-Path
+    $pythonPath = Find-Python
+}
+if ($pythonPath) {
+    $pythonVersion = & $pythonPath --version 2>&1
+    # Prepend real Python dir so it wins over the Windows Store alias
+    $env:Path = (Split-Path $pythonPath) + ";" + $env:Path
+    # Tell node-gyp exactly which Python to use (bypasses its own PATH search)
+    $env:NODE_GYP_FORCE_PYTHON = $pythonPath
+    Write-Host "✓ $pythonVersion ($pythonPath)" -ForegroundColor Green
+} else {
+    Write-Host "✗ Python installation failed — no python.exe found in standard locations." -ForegroundColor Red
+    exit 1
 }
 
-# Install Visual Studio Build Tools
+# --- Visual Studio Build Tools (C++ compiler for native modules) ---
 Write-Host ""
 Write-Host "Checking Visual Studio Build Tools..." -ForegroundColor Yellow
-$vsBuildTools = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools"
-if (Test-Path $vsBuildTools) {
-    Write-Host "✓ Visual Studio Build Tools 2022 found" -ForegroundColor Green
-} else {
+$vsFound = $false
+$vsSearchPaths = @(
+    "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools",
+    "C:\Program Files\Microsoft Visual Studio\2022\BuildTools",
+    "C:\Program Files (x86)\Microsoft Visual Studio\2022\Community",
+    "C:\Program Files\Microsoft Visual Studio\2022\Community",
+    "C:\Program Files (x86)\Microsoft Visual Studio\2022\Professional",
+    "C:\Program Files\Microsoft Visual Studio\2022\Professional",
+    "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise",
+    "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+)
+foreach ($p in $vsSearchPaths) {
+    if (Test-Path $p) {
+        $vsFound = $true
+        Write-Host "✓ Visual Studio 2022 found at $p" -ForegroundColor Green
+        break
+    }
+}
+if (-not $vsFound) {
     Write-Host "Visual Studio Build Tools not found. Installing..." -ForegroundColor Yellow
     Write-Host "This will take several minutes (downloading ~2-3 GB)..." -ForegroundColor Yellow
-    winget install Microsoft.VisualStudio.2022.BuildTools --silent --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+    winget install Microsoft.VisualStudio.2022.BuildTools --silent --accept-package-agreements --accept-source-agreements --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "✗ Failed to install VS Build Tools (exit code $LASTEXITCODE)." -ForegroundColor Red
+        exit 1
+    }
     Write-Host "✓ Visual Studio Build Tools installed" -ForegroundColor Green
 }
 
 Write-Host ""
-Write-Host "=== Setup Complete ===" -ForegroundColor Green
+Write-Host "=== Prerequisites ready ===" -ForegroundColor Green
 Write-Host ""
 
-# Install npm dependencies
+# --- npm install ---
 Write-Host "Installing npm dependencies..." -ForegroundColor Yellow
-try {
-    npm install
-    Write-Host "✓ npm dependencies installed" -ForegroundColor Green
-} catch {
-    Write-Host "✗ Failed to install npm dependencies. You may need to restart your terminal first." -ForegroundColor Red
-    Write-Host "After restarting, run: npm install" -ForegroundColor Yellow
+npm install
+if ($LASTEXITCODE -ne 0) {
+    Write-Host ""
+    Write-Host "✗ npm install failed (exit code $LASTEXITCODE)." -ForegroundColor Red
+    exit 1
 }
+Write-Host "✓ npm dependencies installed" -ForegroundColor Green
 
 Write-Host ""
 Write-Host "=== All Done! ===" -ForegroundColor Green


### PR DESCRIPTION
## Problem

The Windows setup script (`setup-windows.ps1`) failed on fresh machines because:

1. **Windows Store \\python.exe\\ alias** was detected as real Python — PowerShell's \\	ry/catch\\ doesn't catch native command failures, so the script falsely reported Python as installed
2. **PATH ordering** — even after installing Python via winget, the Windows Store alias in \\WindowsApps\\ could still intercept \\python\\ before the real binary
3. **node-gyp couldn't find Python** — \\@electron/rebuild\\ for \\
ode-pty\\ failed during \\
pm install\\
4. **Silent failures everywhere** — winget install failures, npm install failures all went undetected

## Solution

Rewrote the script with helpers that **bypass these issues and complete on first run**:

| Mechanism | What it does |
|---|---|
| \\Find-Python\\ | Scans known install dirs, explicitly **skips WindowsApps aliases** |
| \\Find-Node\\ | Same pattern for \\
ode.exe\\ |
| **PATH prepend** | After finding/installing a binary, prepends its dir to \\\C:\Program Files\PowerShell\7;C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files\Azure Dev CLI;C:\Program Files\GitHub CLI\;C:\Users\vmadmin\AppData\Local\Microsoft\WindowsApps;C:\Program Files\Microsoft SQL Server\170\Tools\Binn\;C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\170\Tools\Binn\;C:\Program Files\dotnet\;C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\;C:\Program Files\PowerShell\7\;C:\Program Files\WindowsApps;C:\Program Files\Git\cmd;C:\Program Files\Microsoft VS Code\bin;Q:\.tools\dotnet;Q:\.tools\.npm-global;C:\ProgramData\chocolatey\bin;C:\ES.DevProd\SpringBoard\SBCli\SpringBoardCli;C:\ES.DevProd\VMSetupScripts;C:\Program Files\nodejs\;C:\ProgramData\global-npm;Q:\.tools\QuickBuild;C:\Windows\system32\config\systemprofile\AppData\Local\Microsoft\WindowsApps;;C:\Program Files\Microsoft Dev Box Agent\Scripts;C:\Users\idof\AppData\Local\Microsoft\WindowsApps;\\ so it wins over aliases |
| \\NODE_GYP_FORCE_PYTHON\\ | Tells node-gyp the exact Python path — bypasses its own PATH search |
| **\\\0\\ checks** | All native commands validated properly instead of \\	ry/catch\\ |
| **\\--accept-package-agreements\\** | Prevents winget from hanging on first use |
| **Broader VS detection** | Checks BuildTools, Community, Professional, and Enterprise editions |

No more 'restart your terminal' messages — everything resolves in-session.