### PR TITLE
Release Cooper 1.0.0 — resolve merge conflicts & update release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,44 +5,44 @@ All notable changes to Cooper will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.5.5
+## 1.0.0
+
+Cooper is a fresh start — a rebrand and ground-up evolution of what was previously Copilot Skins. This release marks the first official version under the new name.
 
 ### Added
 
+- **Voice Control**: "Hey GitHub" hands-free voice interaction with speech-to-text, text-to-speech, transcript normalization, and a persistent mute toggle
+- **Integrated Terminal**: Full PTY-based terminal embedded in the app with run-in-terminal support for code blocks, Ctrl/Cmd+C smart copy, and copy-last-run
+- **Welcome Wizard**: Guided onboarding spotlight tour shown on first launch
+- **Responsive Layout**: Adaptive UI that works across different window sizes
 - **File Preview Revamp**: View changed files in tree or flat view with full diffs, and untrack temporary files you don't want to commit
 - **Mark as Unread**: Flag sessions you want to revisit and add notes for context
-- **Copy Last Run**: New terminal option to quickly copy the output of the last command
-- **Run in Terminal**: Execute command blocks from the conversation directly in the integrated terminal
-
-### Fixed
-
-- Improved startup latency and faster loading of the session history pane
-
----
-
-## 1.1.0
-
-### Added
-
-- **Staging Build Workflow**: New staging branch for thorough testing before production releases
-- **Version Update Notifications**: Popup alerts when a new version is available, with "Don't remind me" option
-- **Release Notes Display**: Automatic display of release notes on first startup of a new version
-- **Automatic Version Bumping**: Minor versions are automatically incremented when releasing from staging to main
+- **Settings Modal**: Sound toggle, TTS mute, and other preferences with persistent state
+- **Tool Activity Display**: Live display of tool calls and activity inside assistant messages
+- **Visual Attention Alerts**: Cross-platform visual cues (window bounce/flash) when the assistant needs your attention
+- **Help Tooltips**: Command description tooltips in the confirmation modal
+- **Kawaii Theme**: New built-in theme option
+- **Claude Opus 4.6**: Added to available model list
+- **Telemetry**: Microsoft Clarity integration with environment tagging, stable installation IDs, and sensitive-data masking
+- **Version Notifications**: Popup alerts when a new version is available, with release notes shown on first startup
 
 ### Changed
 
-- Improved release process with GitHub Actions workflows for staging and production
+- **Rebranded from Copilot Skins to Cooper** across the entire project — name, assets, and documentation
+- Improved startup latency with early client and session initialization
+- Worktree session list loads asynchronously for faster sidebar performance
+- Session names are now the primary display text in session history (branch shown as secondary)
+- Git worktree sessions no longer display disk usage
+- Custom app menu with proper copy/paste handling for terminal compatibility
+- Title bar pulled out into a dedicated component
 
----
+### Fixed
 
-## 1.0.0
-
-### Added
-
-- Initial release of Cooper
-- Native desktop GUI for GitHub Copilot
-- Multiple theme support
-- Worktree session management
-- MCP server integration
-- Terminal integration
-- Ralph and Lisa AI agent modes
+- Terminal PTY crash in dev mode caused by React StrictMode double-mount
+- Unzipper bundling issues causing crashes on Mac and AWS SDK errors at startup
+- Windows setup script hardened for reliable first-run completion
+- Branch names sanitized for git worktree compatibility
+- Scroll-to-bottom logic improved for chat messages and session switching
+- File preview now shows content for untracked new files when diff is unavailable
+- Duplicate CopilotClient creation prevented for same working directory
+- Correct target branch used in merge operations


### PR DESCRIPTION
Resolves all 24 merge conflicts (taking staging versions) and rewrites RELEASE_NOTES.md as a clean Cooper 1.0.0 entry.

Once merged to staging, PR #235 will carry these changes into main.