### PR TITLE
Update GitHub repo owner from idofrizler to CooperAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A native desktop GUI for GitHub Copilot, built on the [Copilot SDK](https://github.blog/changelog/2026-01-14-copilot-sdk-in-technical-preview/).
 
-![Cooper Demo](https://github.com/idofrizler/cooper/releases/download/assets/Copilot.Skins.2-4.gif)
+![Cooper Demo](https://github.com/CooperAgent/cooper/releases/download/assets/Copilot.Skins.2-4.gif)
 
 ## Features
 
@@ -28,13 +28,13 @@ You need **Node.js 22+**, a **GitHub Copilot subscription**, and **GitHub CLI** 
 ### macOS
 
 ```bash
-git clone https://github.com/idofrizler/cooper.git && cd cooper && npm install && npm run dist && open release/Cooper-*-arm64.dmg
+git clone https://github.com/CooperAgent/cooper.git && cd cooper && npm install && npm run dist && open release/Cooper-*-arm64.dmg
 ```
 
 ### Windows
 
 ```powershell
-git clone https://github.com/idofrizler/cooper.git; cd cooper; pwsh -NoProfile -File .\scripts\setup-windows.ps1; npm run dist:win
+git clone https://github.com/CooperAgent/cooper.git; cd cooper; pwsh -NoProfile -File .\scripts\setup-windows.ps1; npm run dist:win
 ```
 
 The setup script installs all Windows-specific prerequisites (Python, VS Build Tools, PowerShell 7+) and npm dependencies automatically.
@@ -57,7 +57,7 @@ If the automated script fails, install these manually:
 
 Tell your agent:
 
-> Clone `https://github.com/idofrizler/cooper.git`, install dependencies, and build an installer for my OS (macOS → `.dmg`, Windows → `.exe`).
+> Clone `https://github.com/CooperAgent/cooper.git`, install dependencies, and build an installer for my OS (macOS → `.dmg`, Windows → `.exe`).
 
 </details>
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4679,7 +4679,7 @@ ipcMain.handle('file:openFile', async (_event, filePath: string) => {
 // ============================================================================
 
 // GitHub repository for checking updates
-const GITHUB_REPO_OWNER = 'idofrizler';
+const GITHUB_REPO_OWNER = 'CooperAgent';
 const GITHUB_REPO_NAME = 'cooper';
 
 interface GitHubRelease {

--- a/src/renderer/components/UpdateAvailableModal/UpdateAvailableModal.tsx
+++ b/src/renderer/components/UpdateAvailableModal/UpdateAvailableModal.tsx
@@ -23,7 +23,7 @@ export const UpdateAvailableModal: React.FC<UpdateAvailableModalProps> = ({
   };
 
   const handleOpenReleases = () => {
-    window.electronAPI.updates.openDownloadUrl('https://github.com/idofrizler/cooper');
+    window.electronAPI.updates.openDownloadUrl('https://github.com/CooperAgent/cooper');
   };
 
   return (


### PR DESCRIPTION
## Summary
- Migrate all repository references from `idofrizler` to the new `CooperAgent` organization
- Update README clone URLs, demo image link, and agent install instructions
- Update GitHub repo owner constant in the auto-update checker (`main.ts`)
- Update release download URL in `UpdateAvailableModal`

## Test plan
- [ ] Verify README links resolve correctly to the new org
- [ ] Verify auto-update checker fetches releases from `CooperAgent/cooper`
- [ ] Verify "Open Releases" button in update modal navigates to the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)