### PR TITLE
ci: add manual Windows installer build to Build Staging workflow

### DIFF
--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -5,9 +5,16 @@ on:
     branches: [staging]
   pull_request:
     branches: [staging]
+  workflow_dispatch:
+    inputs:
+      build_installer:
+        description: 'Build and publish Windows .exe installer as pre-release'
+        required: true
+        default: false
+        type: boolean
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: staging-${{ github.ref }}
@@ -58,3 +65,57 @@ jobs:
 
       - name: Build application
         run: npm run build
+
+  build-windows-installer:
+    if: github.event_name == 'workflow_dispatch' && inputs.build_installer
+    needs: test
+    runs-on: windows-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts && npx patch-package
+
+      - name: Cache node-pty build
+        id: cache-node-pty
+        uses: actions/cache@v4
+        with:
+          path: node_modules/node-pty/build
+          key: node-pty-Windows-node22-electron-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            node-pty-Windows-node22-electron-
+
+      - name: Rebuild node-pty (cache miss)
+        if: steps.cache-node-pty.outputs.cache-hit != 'true'
+        run: npx @electron/rebuild -w node-pty
+
+      - name: Build and package Windows installer
+        run: npm run prebuild-info && electron-vite build && npx electron-builder --win
+
+      - name: Get version
+        id: version
+        run: |
+          $version = node -p "require('./package.json').version"
+          echo "version=$version" >> $env:GITHUB_OUTPUT
+        shell: pwsh
+
+      - name: Create staging pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}-staging.${{ github.run_number }}
+          name: v${{ steps.version.outputs.version }} (Staging)
+          body: |
+            ⚠️ **Staging build — for testing only.**
+
+            Built from `staging` branch, commit ${{ github.sha }}.
+          prerelease: true
+          files: |
+            release/*.exe


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger with a `build_installer` checkbox to the existing Build Staging workflow. When triggered manually, builds Windows NSIS + portable .exe and publishes as a pre-release.

This is CI-only — no code changes.