### PR TITLE
fix: handle array paths in MCP tool display

### DIFF
--- a/src/renderer/features/chat/ToolActivitySection.tsx
+++ b/src/renderer/features/chat/ToolActivitySection.tsx
@@ -11,8 +11,10 @@ type GroupedTool = { tool: ActiveTool; count: number };
 
 const getDescription = (tool: ActiveTool): string => {
   const input = tool.input || {};
-  const path = input.path as string | undefined;
-  const shortPath = path ? path.split('/').slice(-2).join('/') : '';
+  const rawPath = input.path;
+  // Handle path as string or array (MCP tools can pass arrays)
+  const path = Array.isArray(rawPath) ? rawPath.join(', ') : (rawPath as string | undefined);
+  const shortPath = path && typeof path === 'string' ? path.split('/').slice(-2).join('/') : '';
 
   if (tool.toolName === 'grep') {
     const pattern = (input.pattern as string) || '';


### PR DESCRIPTION
## Problem

MCP tool `ado-search_code` passed `path` as an array:
```json
{
  "path": ["documentation/schedule.md"]
}
```

This caused a crash in `ToolActivitySection.tsx`:
```
TypeError: path.split is not a function
    at getDescription (ToolActivitySection.tsx:15:33)
```

## Solution

Added array handling in `getDescription`:
- Convert array paths to comma-separated strings
- Add type check before calling `.split()`

## Testing

Tested with `npm run preview` using the same MCP tool that caused the crash.