### PR TITLE
feat: add refresh instructions button

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -51,6 +51,9 @@ const electronAPI = {
     closeSession: (sessionId: string): Promise<{ success: boolean; remainingSessions: number }> => {
       return ipcRenderer.invoke('copilot:closeSession', sessionId);
     },
+    resumeSession: (sessionId: string): Promise<{ success: boolean; error?: string }> => {
+      return ipcRenderer.invoke('copilot:resumeSession', sessionId);
+    },
     deleteSessionFromHistory: (
       sessionId: string
     ): Promise<{ success: boolean; error?: string }> => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1086,6 +1086,19 @@ const App: React.FC = () => {
     loadInstructions();
   }, [activeTab?.cwd]);
 
+  // Resume current session to refresh instructions from disk
+  const handleResumeSession = useCallback(async () => {
+    if (!activeTab?.id) return;
+    try {
+      const result = await window.electronAPI.copilot.resumeSession(activeTab.id);
+      if (!result.success) {
+        console.error('Failed to resume session:', result.error);
+      }
+    } catch (error) {
+      console.error('Error resuming session:', error);
+    }
+  }, [activeTab?.id]);
+
   const handleOpenEnvironment = useCallback(
     (tab: 'instructions' | 'skills' | 'agents', event?: React.MouseEvent, itemPath?: string) => {
       event?.stopPropagation();
@@ -4610,19 +4623,28 @@ Only when ALL the above are verified complete, output exactly: ${RALPH_COMPLETIO
 
               {/* Copilot Instructions */}
               <div className="border-b border-copilot-border">
-                <button
-                  onClick={() => setShowInstructions(!showInstructions)}
-                  className="w-full flex items-center gap-3 px-4 py-3 text-sm text-copilot-text-muted hover:text-copilot-text hover:bg-copilot-surface transition-colors"
-                >
-                  <ChevronRightIcon
-                    size={14}
-                    className={`transition-transform ${showInstructions ? 'rotate-90' : ''}`}
-                  />
-                  <span>Instructions</span>
-                  {instructions.length > 0 && (
-                    <span className="ml-auto text-copilot-accent">{instructions.length}</span>
-                  )}
-                </button>
+                <div className="flex items-center">
+                  <button
+                    onClick={() => setShowInstructions(!showInstructions)}
+                    className="flex-1 flex items-center gap-3 px-4 py-3 text-sm text-copilot-text-muted hover:text-copilot-text hover:bg-copilot-surface transition-colors"
+                  >
+                    <ChevronRightIcon
+                      size={14}
+                      className={`transition-transform ${showInstructions ? 'rotate-90' : ''}`}
+                    />
+                    <span>Instructions</span>
+                    {instructions.length > 0 && (
+                      <span className="ml-auto text-copilot-accent">{instructions.length}</span>
+                    )}
+                  </button>
+                  <button
+                    onClick={handleResumeSession}
+                    className="px-3 py-3 text-copilot-text-muted hover:text-copilot-accent hover:bg-copilot-surface transition-colors"
+                    title="Refresh instructions (restart SDK)"
+                  >
+                    <RepeatIcon size={14} />
+                  </button>
+                </div>
                 {showInstructions && (
                   <div>
                     {flatInstructions.length === 0 ? (
@@ -7139,19 +7161,28 @@ Only when ALL the above are verified complete, output exactly: ${RALPH_COMPLETIO
 
                     {/* Copilot Instructions */}
                     <div>
-                      <button
-                        onClick={() => setShowInstructions(!showInstructions)}
-                        className="w-full flex items-center gap-2 px-3 py-2 text-xs text-copilot-text-muted hover:text-copilot-text hover:bg-copilot-surface transition-colors"
-                      >
-                        <ChevronRightIcon
-                          size={8}
-                          className={`transition-transform ${showInstructions ? 'rotate-90' : ''}`}
-                        />
-                        <span>Instructions</span>
-                        {instructions.length > 0 && (
-                          <span className="text-copilot-accent">({instructions.length})</span>
-                        )}
-                      </button>
+                      <div className="flex items-center">
+                        <button
+                          onClick={() => setShowInstructions(!showInstructions)}
+                          className="flex-1 flex items-center gap-2 px-3 py-2 text-xs text-copilot-text-muted hover:text-copilot-text hover:bg-copilot-surface transition-colors"
+                        >
+                          <ChevronRightIcon
+                            size={8}
+                            className={`transition-transform ${showInstructions ? 'rotate-90' : ''}`}
+                          />
+                          <span>Instructions</span>
+                          {instructions.length > 0 && (
+                            <span className="text-copilot-accent">({instructions.length})</span>
+                          )}
+                        </button>
+                        <button
+                          onClick={handleResumeSession}
+                          className="px-2 py-2 text-copilot-text-muted hover:text-copilot-accent hover:bg-copilot-surface transition-colors"
+                          title="Refresh instructions (restart SDK)"
+                        >
+                          <RepeatIcon size={10} />
+                        </button>
+                      </div>
                       {showInstructions && (
                         <div className="max-h-48 overflow-y-auto">
                           {flatInstructions.length === 0 ? (


### PR DESCRIPTION
Add a refresh button next to Instructions in the right panel that kills the SDK client and creates a fresh one, forcing instruction files to be re-read from disk.

The SDK caches instructions at the client level, so a full client restart is required to pick up changes.


Before (instructions changed between chats).:
<img width="802" height="250" alt="image" src="https://github.com/user-attachments/assets/a812aa21-5956-4f83-8aa7-1c4e63e03f57" />
Creating new session - still no change. Stuck talking like an Australian!

After:
<img width="1108" height="291" alt="image" src="https://github.com/user-attachments/assets/33569cc0-e5ae-49f3-a2bd-7b96d7918b0e" />
In between "hi", I changed instructions and hit the refresh button near instructions. Results - now talking like a pirate