### PR TITLE
fix: symlink gh config in dev-env.js to preserve auth on Unix

### DIFF
--- a/scripts/dev-env.js
+++ b/scripts/dev-env.js
@@ -1,8 +1,27 @@
-const { homedir } = require('os');
+const { homedir, platform } = require('os');
 const { join } = require('path');
 const { execSync } = require('child_process');
+const { existsSync, mkdirSync, symlinkSync, lstatSync } = require('fs');
 
 const devHome = join(homedir(), '.cooper-dev');
+
+// On Unix systems, symlink ~/.config/gh to ~/.cooper-dev/gh so gh CLI auth works
+// when XDG_CONFIG_HOME is overridden. Windows ignores XDG_CONFIG_HOME entirely.
+if (platform() !== 'win32') {
+  const ghConfigSource = join(homedir(), '.config', 'gh');
+  const ghConfigDest = join(devHome, 'gh');
+
+  if (existsSync(ghConfigSource) && !existsSync(ghConfigDest)) {
+    mkdirSync(devHome, { recursive: true });
+    try {
+      symlinkSync(ghConfigSource, ghConfigDest);
+      console.log(`[dev-env] Symlinked ${ghConfigSource} -> ${ghConfigDest}`);
+    } catch (err) {
+      console.warn(`[dev-env] Could not symlink gh config: ${err.message}`);
+    }
+  }
+}
+
 process.env.XDG_CONFIG_HOME = devHome;
 process.env.XDG_STATE_HOME = devHome;
 process.env.COPILOT_SESSIONS_HOME = join(devHome, 'sessions');


### PR DESCRIPTION
## Summary

Running `npm run dev` on Linux/macOS caused Copilot SDK authentication to fail because `dev-env.js` overrides `XDG_CONFIG_HOME`, which breaks `gh` CLI ability to find its auth token.

## Root Cause

`scripts/dev-env.js` sets `XDG_CONFIG_HOME=~/.cooper-dev`, but `gh` CLI follows the XDG spec and looks for config at `$XDG_CONFIG_HOME/gh/hosts.yml` instead of the default `~/.config/gh/hosts.yml`.

## Fix

On Unix systems, automatically symlink `~/.config/gh` to `~/.cooper-dev/gh` before overriding `XDG_CONFIG_HOME`. This preserves dev isolation while allowing `gh` to find its auth token.

Windows is unaffected since it ignores `XDG_CONFIG_HOME` entirely.

## Testing

- All 395 unit tests pass
- Requires manual verification on Linux/macOS:
  1. Remove any existing symlink: `rm ~/.cooper-dev/gh`
  2. Run `npm run dev`
  3. Confirm auth works and chat responds