### PR TITLE
perf: memoize message list rendering to fix keypress latency (#271)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -473,7 +473,7 @@ const App: React.FC = () => {
 
   // Voice speech hook for STT/TTS
   const voiceSpeech = useVoiceSpeech();
-  const { isRecording } = voiceSpeech;
+  const { isRecording, isSpeaking: voiceIsSpeaking, stopSpeaking: voiceStopSpeaking } = voiceSpeech;
   const voiceSpeakRef = useRef(voiceSpeech.speak);
   voiceSpeakRef.current = voiceSpeech.speak; // Keep ref updated
 
@@ -4292,6 +4292,304 @@ Only when ALL the above are verified complete, output exactly: ${RALPH_COMPLETIO
     }
   }, [activeTab]);
 
+  // Memoize filtered messages to avoid re-computation on every render (#271)
+  const filteredMessages = useMemo(() => {
+    return (activeTab?.messages || [])
+      .filter((m) => m.role !== 'system')
+      .filter((m) => m.role === 'user' || m.content.trim());
+  }, [activeTab?.messages]);
+
+  const lastAssistantIndex = useMemo(() => {
+    for (let i = filteredMessages.length - 1; i >= 0; i--) {
+      if (filteredMessages[i].role === 'assistant') {
+        return i;
+      }
+    }
+    return -1;
+  }, [filteredMessages]);
+
+  // Memoize rendered message list JSX to prevent re-computation when
+  // inputValue changes. Core fix for ~185ms keypress latency (#271).
+  const renderedMessageList = useMemo(
+    () =>
+      filteredMessages.map((message, index) => (
+        <div
+          key={message.id}
+          className={`flex flex-col ${message.role === 'user' ? 'items-end' : 'items-start'}`}
+        >
+          <div
+            className={`max-w-[85%] rounded-lg px-4 py-2.5 overflow-hidden relative ${
+              message.role === 'user'
+                ? message.isPendingInjection
+                  ? 'bg-copilot-warning text-white border border-dashed border-copilot-warning/50'
+                  : 'bg-copilot-success text-copilot-text-inverse'
+                : 'bg-copilot-surface text-copilot-text'
+            }`}
+          >
+            {/* Stop speaking overlay on last assistant message */}
+            {message.role === 'assistant' && index === lastAssistantIndex && voiceIsSpeaking && (
+              <button
+                onClick={() => voiceStopSpeaking()}
+                className="absolute top-1.5 right-1.5 flex items-center gap-1 px-2 py-1 text-[10px] font-medium bg-copilot-warning text-white rounded-md hover:bg-copilot-warning/80 transition-colors z-10"
+                title="Stop reading aloud"
+              >
+                <VolumeMuteIcon size={12} />
+                Stop
+              </button>
+            )}
+            {/* Pending injection indicator */}
+            {message.isPendingInjection && (
+              <div className="flex items-center gap-1.5 text-[10px] opacity-80 mb-1.5">
+                <ClockIcon size={10} />
+                <span>Pending — will be read by agent</span>
+              </div>
+            )}
+            <div className="text-sm break-words overflow-hidden">
+              {message.role === 'user' ? (
+                <>
+                  {/* User message images */}
+                  {message.imageAttachments && message.imageAttachments.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mb-2">
+                      {message.imageAttachments.map((img) => (
+                        <img
+                          key={img.id}
+                          src={img.previewUrl}
+                          alt={img.name}
+                          className="max-h-32 w-auto rounded border border-white/30 object-contain cursor-pointer hover:opacity-80 transition-opacity"
+                          onClick={() => setLightboxImage({ src: img.previewUrl, alt: img.name })}
+                          title="Click to enlarge"
+                        />
+                      ))}
+                    </div>
+                  )}
+                  {/* User message files */}
+                  {message.fileAttachments && message.fileAttachments.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mb-2">
+                      {message.fileAttachments.map((file) => (
+                        <div
+                          key={file.id}
+                          className="flex items-center gap-2 px-2.5 py-1.5 bg-black/20 rounded-lg"
+                        >
+                          <FileIcon size={16} className="opacity-60 shrink-0" />
+                          <div className="flex flex-col min-w-0">
+                            <span className="text-xs truncate max-w-[150px]" title={file.name}>
+                              {file.name}
+                            </span>
+                            <span className="text-[10px] opacity-50">
+                              {(file.size / 1024).toFixed(1)} KB
+                            </span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {/* Render user message content - use ReactMarkdown if it contains code blocks */}
+                  {message.content.includes('```') ? (
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm]}
+                      components={{
+                        p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+                        code: ({ className, children }) => {
+                          const textContent = String(children).replace(/\n$/, '');
+                          const hasLanguageClass = className?.startsWith('language-');
+                          const isMultiLine = textContent.includes('\n');
+                          const isBlock = hasLanguageClass || isMultiLine;
+
+                          if (isBlock) {
+                            return (
+                              <CodeBlockWithCopy
+                                isDiagram={false}
+                                textContent={textContent}
+                                isCliCommand={false}
+                              >
+                                {children}
+                              </CodeBlockWithCopy>
+                            );
+                          } else {
+                            return (
+                              <code className="bg-copilot-bg px-1 py-0.5 rounded text-copilot-warning text-xs break-all">
+                                {children}
+                              </code>
+                            );
+                          }
+                        },
+                        pre: ({ children }) => (
+                          <div className="overflow-x-auto max-w-full">{children}</div>
+                        ),
+                      }}
+                    >
+                      {message.content}
+                    </ReactMarkdown>
+                  ) : (
+                    <span className="whitespace-pre-wrap break-words">{message.content}</span>
+                  )}
+                </>
+              ) : (
+                <>
+                  {/* Tool Activity Section for assistant messages */}
+                  {(() => {
+                    // Show live tools only if this message is actively streaming with content
+                    // (otherwise tools show in the thinking bubble)
+                    // For completed messages, show stored tools
+                    const isLive = message.isStreaming && message.content;
+                    const toolsToShow = isLive ? activeTab?.activeTools : message.tools;
+                    const subagentsToShow = isLive ? activeTab?.activeSubagents : message.subagents;
+                    if (toolsToShow && toolsToShow.length > 0) {
+                      return <ToolActivitySection tools={toolsToShow} isLive={!!isLive} />;
+                    }
+                    if (subagentsToShow && subagentsToShow.length > 0) {
+                      return (
+                        <SubagentActivitySection subagents={subagentsToShow} isLive={!!isLive} />
+                      );
+                    }
+                    return null;
+                  })()}
+                  {message.content ? (
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm]}
+                      components={{
+                        p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+                        strong: ({ children }) => (
+                          <strong className="font-semibold text-copilot-text">{children}</strong>
+                        ),
+                        em: ({ children }) => <em className="italic">{children}</em>,
+                        ul: ({ children }) => (
+                          <ul className="list-disc list-inside mb-2 space-y-1">{children}</ul>
+                        ),
+                        ol: ({ children }) => (
+                          <ol className="list-decimal list-inside mb-2 space-y-1">{children}</ol>
+                        ),
+                        li: ({ children }) => <li className="ml-2">{children}</li>,
+                        code: ({ children, className }) => {
+                          // Extract text content for analysis
+                          const textContent = extractTextContent(children);
+
+                          // Fix block detection: treat as block if:
+                          // 1. Has language class (e.g., language-javascript)
+                          // 2. OR contains newlines (multi-line content)
+                          const hasLanguageClass = className?.includes('language-');
+                          const isMultiLine = textContent.includes('\n');
+                          const isBlock = hasLanguageClass || isMultiLine;
+
+                          // Check if content is an ASCII diagram
+                          const isDiagram = isAsciiDiagram(textContent);
+
+                          // Check if this is a CLI command (should show run button)
+                          const isCliCmd = isCliCommand(className, textContent);
+
+                          if (isBlock) {
+                            return (
+                              <CodeBlockWithCopy
+                                isDiagram={isDiagram}
+                                textContent={textContent}
+                                isCliCommand={isCliCmd}
+                              >
+                                {children}
+                              </CodeBlockWithCopy>
+                            );
+                          } else {
+                            return (
+                              <code className="bg-copilot-bg px-1 py-0.5 rounded text-copilot-warning text-xs break-all">
+                                {children}
+                              </code>
+                            );
+                          }
+                        },
+                        pre: ({ children }) => (
+                          <div className="overflow-x-auto max-w-full">{children}</div>
+                        ),
+                        a: ({ href, children }) => (
+                          <a
+                            href={href}
+                            className="text-copilot-accent hover:underline"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {children}
+                          </a>
+                        ),
+                        h1: ({ children }) => (
+                          <h1 className="text-lg font-bold mb-2 text-copilot-text">{children}</h1>
+                        ),
+                        h2: ({ children }) => (
+                          <h2 className="text-base font-bold mb-2 text-copilot-text">{children}</h2>
+                        ),
+                        h3: ({ children }) => (
+                          <h3 className="text-sm font-bold mb-1 text-copilot-text">{children}</h3>
+                        ),
+                        blockquote: ({ children }) => (
+                          <blockquote className="border-l-2 border-copilot-border pl-3 my-2 text-copilot-text-muted italic">
+                            {children}
+                          </blockquote>
+                        ),
+                        table: ({ children }) => (
+                          <div className="overflow-x-auto my-2">
+                            <table className="min-w-full border-collapse border border-copilot-border text-sm">
+                              {children}
+                            </table>
+                          </div>
+                        ),
+                        thead: ({ children }) => (
+                          <thead className="bg-copilot-bg">{children}</thead>
+                        ),
+                        tbody: ({ children }) => <tbody>{children}</tbody>,
+                        tr: ({ children }) => (
+                          <tr className="border-b border-copilot-border">{children}</tr>
+                        ),
+                        th: ({ children }) => (
+                          <th className="px-3 py-2 text-left font-semibold text-copilot-text border border-copilot-border">
+                            {children}
+                          </th>
+                        ),
+                        td: ({ children }) => (
+                          <td className="px-3 py-2 text-copilot-text border border-copilot-border">
+                            {children}
+                          </td>
+                        ),
+                      }}
+                    >
+                      {message.content}
+                    </ReactMarkdown>
+                  ) : null}
+                </>
+              )}
+              {message.isStreaming && message.content && (
+                <span className="inline-block w-2 h-4 ml-1 bg-copilot-accent animate-pulse rounded-sm" />
+              )}
+            </div>
+          </div>
+          {/* Show timestamp for the last assistant message (only when not processing) */}
+          {index === lastAssistantIndex && message.timestamp && !activeTab?.isProcessing && (
+            <span className="text-[10px] text-copilot-text-muted mt-1 ml-1">
+              {new Date(message.timestamp).toLocaleTimeString([], {
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </span>
+          )}
+          {/* Show choice selector for the last assistant message when choices are detected */}
+          {index === lastAssistantIndex &&
+            !activeTab?.isProcessing &&
+            activeTab?.detectedChoices &&
+            activeTab.detectedChoices.length > 0 && (
+              <ChoiceSelector choices={activeTab.detectedChoices} onSelect={handleChoiceSelect} />
+            )}
+        </div>
+      )),
+    [
+      filteredMessages,
+      lastAssistantIndex,
+      activeTab?.isProcessing,
+      activeTab?.activeTools,
+      activeTab?.activeSubagents,
+      activeTab?.detectedChoices,
+      handleChoiceSelect,
+      voiceIsSpeaking,
+      voiceStopSpeaking,
+      setLightboxImage,
+    ]
+  );
+
   return (
     <TerminalProvider
       sessionId={activeTab?.id || null}
@@ -5170,318 +5468,7 @@ Only when ALL the above are verified complete, output exactly: ${RALPH_COMPLETIO
                 </div>
               )}
 
-              {(() => {
-                const filteredMessages = (activeTab?.messages || [])
-                  .filter((m) => m.role !== 'system')
-                  .filter((m) => m.role === 'user' || m.content.trim());
-
-                // Find the last assistant message index
-                let lastAssistantIndex = -1;
-                for (let i = filteredMessages.length - 1; i >= 0; i--) {
-                  if (filteredMessages[i].role === 'assistant') {
-                    lastAssistantIndex = i;
-                    break;
-                  }
-                }
-
-                return filteredMessages.map((message, index) => (
-                  <div
-                    key={message.id}
-                    className={`flex flex-col ${message.role === 'user' ? 'items-end' : 'items-start'}`}
-                  >
-                    <div
-                      className={`max-w-[85%] rounded-lg px-4 py-2.5 overflow-hidden relative ${
-                        message.role === 'user'
-                          ? message.isPendingInjection
-                            ? 'bg-copilot-warning text-white border border-dashed border-copilot-warning/50'
-                            : 'bg-copilot-success text-copilot-text-inverse'
-                          : 'bg-copilot-surface text-copilot-text'
-                      }`}
-                    >
-                      {/* Stop speaking overlay on last assistant message */}
-                      {message.role === 'assistant' &&
-                        index === lastAssistantIndex &&
-                        voiceSpeech.isSpeaking && (
-                          <button
-                            onClick={() => voiceSpeech.stopSpeaking()}
-                            className="absolute top-1.5 right-1.5 flex items-center gap-1 px-2 py-1 text-[10px] font-medium bg-copilot-warning text-white rounded-md hover:bg-copilot-warning/80 transition-colors z-10"
-                            title="Stop reading aloud"
-                          >
-                            <VolumeMuteIcon size={12} />
-                            Stop
-                          </button>
-                        )}
-                      {/* Pending injection indicator */}
-                      {message.isPendingInjection && (
-                        <div className="flex items-center gap-1.5 text-[10px] opacity-80 mb-1.5">
-                          <ClockIcon size={10} />
-                          <span>Pending — will be read by agent</span>
-                        </div>
-                      )}
-                      <div className="text-sm break-words overflow-hidden">
-                        {message.role === 'user' ? (
-                          <>
-                            {/* User message images */}
-                            {message.imageAttachments && message.imageAttachments.length > 0 && (
-                              <div className="flex flex-wrap gap-2 mb-2">
-                                {message.imageAttachments.map((img) => (
-                                  <img
-                                    key={img.id}
-                                    src={img.previewUrl}
-                                    alt={img.name}
-                                    className="max-h-32 w-auto rounded border border-white/30 object-contain cursor-pointer hover:opacity-80 transition-opacity"
-                                    onClick={() =>
-                                      setLightboxImage({ src: img.previewUrl, alt: img.name })
-                                    }
-                                    title="Click to enlarge"
-                                  />
-                                ))}
-                              </div>
-                            )}
-                            {/* User message files */}
-                            {message.fileAttachments && message.fileAttachments.length > 0 && (
-                              <div className="flex flex-wrap gap-2 mb-2">
-                                {message.fileAttachments.map((file) => (
-                                  <div
-                                    key={file.id}
-                                    className="flex items-center gap-2 px-2.5 py-1.5 bg-black/20 rounded-lg"
-                                  >
-                                    <FileIcon size={16} className="opacity-60 shrink-0" />
-                                    <div className="flex flex-col min-w-0">
-                                      <span
-                                        className="text-xs truncate max-w-[150px]"
-                                        title={file.name}
-                                      >
-                                        {file.name}
-                                      </span>
-                                      <span className="text-[10px] opacity-50">
-                                        {(file.size / 1024).toFixed(1)} KB
-                                      </span>
-                                    </div>
-                                  </div>
-                                ))}
-                              </div>
-                            )}
-                            {/* Render user message content - use ReactMarkdown if it contains code blocks */}
-                            {message.content.includes('```') ? (
-                              <ReactMarkdown
-                                remarkPlugins={[remarkGfm]}
-                                components={{
-                                  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-                                  code: ({ className, children }) => {
-                                    const textContent = String(children).replace(/\n$/, '');
-                                    const hasLanguageClass = className?.startsWith('language-');
-                                    const isMultiLine = textContent.includes('\n');
-                                    const isBlock = hasLanguageClass || isMultiLine;
-
-                                    if (isBlock) {
-                                      return (
-                                        <CodeBlockWithCopy
-                                          isDiagram={false}
-                                          textContent={textContent}
-                                          isCliCommand={false}
-                                        >
-                                          {children}
-                                        </CodeBlockWithCopy>
-                                      );
-                                    } else {
-                                      return (
-                                        <code className="bg-copilot-bg px-1 py-0.5 rounded text-copilot-warning text-xs break-all">
-                                          {children}
-                                        </code>
-                                      );
-                                    }
-                                  },
-                                  pre: ({ children }) => (
-                                    <div className="overflow-x-auto max-w-full">{children}</div>
-                                  ),
-                                }}
-                              >
-                                {message.content}
-                              </ReactMarkdown>
-                            ) : (
-                              <span className="whitespace-pre-wrap break-words">
-                                {message.content}
-                              </span>
-                            )}
-                          </>
-                        ) : (
-                          <>
-                            {/* Tool Activity Section for assistant messages */}
-                            {(() => {
-                              // Show live tools only if this message is actively streaming with content
-                              // (otherwise tools show in the thinking bubble)
-                              // For completed messages, show stored tools
-                              const isLive = message.isStreaming && message.content;
-                              const toolsToShow = isLive ? activeTab?.activeTools : message.tools;
-                              const subagentsToShow = isLive
-                                ? activeTab?.activeSubagents
-                                : message.subagents;
-                              if (toolsToShow && toolsToShow.length > 0) {
-                                return (
-                                  <ToolActivitySection tools={toolsToShow} isLive={!!isLive} />
-                                );
-                              }
-                              if (subagentsToShow && subagentsToShow.length > 0) {
-                                return (
-                                  <SubagentActivitySection
-                                    subagents={subagentsToShow}
-                                    isLive={!!isLive}
-                                  />
-                                );
-                              }
-                              return null;
-                            })()}
-                            {message.content ? (
-                              <ReactMarkdown
-                                remarkPlugins={[remarkGfm]}
-                                components={{
-                                  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-                                  strong: ({ children }) => (
-                                    <strong className="font-semibold text-copilot-text">
-                                      {children}
-                                    </strong>
-                                  ),
-                                  em: ({ children }) => <em className="italic">{children}</em>,
-                                  ul: ({ children }) => (
-                                    <ul className="list-disc list-inside mb-2 space-y-1">
-                                      {children}
-                                    </ul>
-                                  ),
-                                  ol: ({ children }) => (
-                                    <ol className="list-decimal list-inside mb-2 space-y-1">
-                                      {children}
-                                    </ol>
-                                  ),
-                                  li: ({ children }) => <li className="ml-2">{children}</li>,
-                                  code: ({ children, className }) => {
-                                    // Extract text content for analysis
-                                    const textContent = extractTextContent(children);
-
-                                    // Fix block detection: treat as block if:
-                                    // 1. Has language class (e.g., language-javascript)
-                                    // 2. OR contains newlines (multi-line content)
-                                    const hasLanguageClass = className?.includes('language-');
-                                    const isMultiLine = textContent.includes('\n');
-                                    const isBlock = hasLanguageClass || isMultiLine;
-
-                                    // Check if content is an ASCII diagram
-                                    const isDiagram = isAsciiDiagram(textContent);
-
-                                    // Check if this is a CLI command (should show run button)
-                                    const isCliCmd = isCliCommand(className, textContent);
-
-                                    if (isBlock) {
-                                      return (
-                                        <CodeBlockWithCopy
-                                          isDiagram={isDiagram}
-                                          textContent={textContent}
-                                          isCliCommand={isCliCmd}
-                                        >
-                                          {children}
-                                        </CodeBlockWithCopy>
-                                      );
-                                    } else {
-                                      return (
-                                        <code className="bg-copilot-bg px-1 py-0.5 rounded text-copilot-warning text-xs break-all">
-                                          {children}
-                                        </code>
-                                      );
-                                    }
-                                  },
-                                  pre: ({ children }) => (
-                                    <div className="overflow-x-auto max-w-full">{children}</div>
-                                  ),
-                                  a: ({ href, children }) => (
-                                    <a
-                                      href={href}
-                                      className="text-copilot-accent hover:underline"
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                    >
-                                      {children}
-                                    </a>
-                                  ),
-                                  h1: ({ children }) => (
-                                    <h1 className="text-lg font-bold mb-2 text-copilot-text">
-                                      {children}
-                                    </h1>
-                                  ),
-                                  h2: ({ children }) => (
-                                    <h2 className="text-base font-bold mb-2 text-copilot-text">
-                                      {children}
-                                    </h2>
-                                  ),
-                                  h3: ({ children }) => (
-                                    <h3 className="text-sm font-bold mb-1 text-copilot-text">
-                                      {children}
-                                    </h3>
-                                  ),
-                                  blockquote: ({ children }) => (
-                                    <blockquote className="border-l-2 border-copilot-border pl-3 my-2 text-copilot-text-muted italic">
-                                      {children}
-                                    </blockquote>
-                                  ),
-                                  table: ({ children }) => (
-                                    <div className="overflow-x-auto my-2">
-                                      <table className="min-w-full border-collapse border border-copilot-border text-sm">
-                                        {children}
-                                      </table>
-                                    </div>
-                                  ),
-                                  thead: ({ children }) => (
-                                    <thead className="bg-copilot-bg">{children}</thead>
-                                  ),
-                                  tbody: ({ children }) => <tbody>{children}</tbody>,
-                                  tr: ({ children }) => (
-                                    <tr className="border-b border-copilot-border">{children}</tr>
-                                  ),
-                                  th: ({ children }) => (
-                                    <th className="px-3 py-2 text-left font-semibold text-copilot-text border border-copilot-border">
-                                      {children}
-                                    </th>
-                                  ),
-                                  td: ({ children }) => (
-                                    <td className="px-3 py-2 text-copilot-text border border-copilot-border">
-                                      {children}
-                                    </td>
-                                  ),
-                                }}
-                              >
-                                {message.content}
-                              </ReactMarkdown>
-                            ) : null}
-                          </>
-                        )}
-                        {message.isStreaming && message.content && (
-                          <span className="inline-block w-2 h-4 ml-1 bg-copilot-accent animate-pulse rounded-sm" />
-                        )}
-                      </div>
-                    </div>
-                    {/* Show timestamp for the last assistant message (only when not processing) */}
-                    {index === lastAssistantIndex &&
-                      message.timestamp &&
-                      !activeTab?.isProcessing && (
-                        <span className="text-[10px] text-copilot-text-muted mt-1 ml-1">
-                          {new Date(message.timestamp).toLocaleTimeString([], {
-                            hour: '2-digit',
-                            minute: '2-digit',
-                          })}
-                        </span>
-                      )}
-                    {/* Show choice selector for the last assistant message when choices are detected */}
-                    {index === lastAssistantIndex &&
-                      !activeTab?.isProcessing &&
-                      activeTab?.detectedChoices &&
-                      activeTab.detectedChoices.length > 0 && (
-                        <ChoiceSelector
-                          choices={activeTab.detectedChoices}
-                          onSelect={handleChoiceSelect}
-                        />
-                      )}
-                  </div>
-                ));
-              })()}
+              {renderedMessageList}
 
               {/* Thinking indicator when processing but no streaming content yet */}
               {activeTab?.isProcessing &&


### PR DESCRIPTION
## Summary

Fixes #271 — Keypress latency of ~185ms in large sessions caused by full re-render of the message list on every keystroke.

## Root Cause

`inputValue` state lives in the App component, triggering a full re-render of the entire component tree (8000+ lines of JSX) on every keystroke. The message list (300+ lines of JSX per message × N messages) was re-rendered despite not depending on `inputValue`.

## Solution

1. **`useMemo` for `filteredMessages`** — Caches the filtered message array, only recomputing when `activeTab.messages` changes
2. **`useMemo` for `lastAssistantIndex`** — Derived from `filteredMessages`, avoids redundant iteration
3. **`useMemo` for `renderedMessageList`** — Memoizes the entire message list JSX output. Dependency array uses specific `activeTab` properties (`isProcessing`, `activeTools`, `activeSubagents`, `detectedChoices`) instead of the whole object for tighter memoization
4. **Destructured `voiceSpeech` hook** — Extracts `isSpeaking` (boolean) and `stopSpeaking` (stable `useCallback`) for referential stability, avoiding the unstable hook return object as a dependency

## Key Insight

`inputValue` is NOT used anywhere in the message rendering block. By isolating the message list into a `useMemo` whose dependency array excludes `inputValue`, the message list JSX is only recomputed when message-related state actually changes.

## Testing

- All 395 tests passing
- Prettier format check passes