### PR TITLE
fix: graceful Windows build when Python is missing (#224)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thanks for your interest in contributing! Here's how to get started.
    ```bash
    npm install
    ```
+   > **Windows users:** `node-pty` requires Python 3 and Visual Studio Build Tools with the "Desktop development with C++" workload. If `npm install` warns about a failed rebuild, install the prerequisites and run `npm run rebuild-pty`. See [node-gyp docs](https://github.com/nodejs/node-gyp#on-windows) for details.
 3. Start the dev server:
    ```bash
    npm run dev

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:e2e:headed": "npm run build && npx playwright test --headed",
     "test:integration": "node --import tsx/esm tests/integration/choice-detection.test.ts",
     "test:all": "npm run test && npm run test:e2e",
-    "postinstall": "npx patch-package && npx @electron/rebuild -w node-pty && node -e \"if(process.platform==='darwin'){require('child_process').execSync('codesign --force --deep --sign - --entitlements build/entitlements.mac.plist node_modules/electron/dist/Electron.app',{stdio:'inherit'})}\"",
+    "postinstall": "node scripts/postinstall.js",
     "rebuild-pty": "npx @electron/rebuild -f -w node-pty",
     "prebuild-info": "node scripts/build-info.js",
     "clean": "node -e \"const fs=require('fs');['out','release'].forEach(d=>{try{fs.rmSync(d,{recursive:true,force:true})}catch{}})\"",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+/**
+ * Postinstall script that handles platform-specific native module setup.
+ * Replaces inline shell commands for better error handling and cross-platform support.
+ *
+ * Steps:
+ * 1. Apply patches via patch-package
+ * 2. Rebuild node-pty for Electron (with graceful failure on missing prerequisites)
+ * 3. Code-sign Electron binary on macOS
+ */
+
+const { execSync } = require('child_process');
+const { existsSync } = require('fs');
+const { join } = require('path');
+
+const isWindows = process.platform === 'win32';
+const isMacOS = process.platform === 'darwin';
+
+function run(cmd, options = {}) {
+  try {
+    execSync(cmd, { stdio: 'inherit', ...options });
+    return true;
+  } catch (error) {
+    if (options.optional) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+// Step 1: Apply patches
+console.log('\n📦 Applying patches...');
+run('npx patch-package');
+
+// Step 2: Rebuild node-pty for Electron
+console.log('\n🔨 Rebuilding node-pty for Electron...');
+const rebuilt = run('npx @electron/rebuild -w node-pty', { optional: true });
+
+if (!rebuilt) {
+  console.warn('\n⚠️  node-pty rebuild failed.');
+  if (isWindows) {
+    console.warn('   On Windows, node-pty requires:');
+    console.warn('   • Python 3.x (https://www.python.org/downloads/)');
+    console.warn('   • Visual Studio Build Tools with "Desktop development with C++" workload');
+    console.warn(
+      '   Install prerequisites: npm install --global windows-build-tools (run as Admin)'
+    );
+    console.warn('   Or install manually: https://github.com/nodejs/node-gyp#on-windows');
+  } else {
+    console.warn('   Ensure build tools are installed (make, gcc/clang, python3).');
+  }
+  console.warn('   The terminal feature will not work until node-pty is rebuilt.');
+  console.warn('   Run "npm run rebuild-pty" after installing prerequisites.\n');
+}
+
+// Step 3: Code-sign Electron on macOS
+if (isMacOS) {
+  const entitlements = join(__dirname, '..', 'build', 'entitlements.mac.plist');
+  const electronApp = join(__dirname, '..', 'node_modules', 'electron', 'dist', 'Electron.app');
+
+  if (existsSync(entitlements) && existsSync(electronApp)) {
+    console.log('\n🔏 Code-signing Electron binary...');
+    run(`codesign --force --deep --sign - --entitlements ${entitlements} ${electronApp}`, {
+      optional: true,
+    });
+  }
+}
+
+console.log('\n✅ Postinstall complete.\n');


### PR DESCRIPTION
## Summary

Closes #224

The postinstall script fatally failed on Windows when Python 3 or Visual Studio Build Tools were missing (required by node-pty's native compilation).

## Changes

- **New `scripts/postinstall.js`**: Cross-platform postinstall script that handles rebuild failures gracefully with clear prerequisite instructions for Windows
- **`package.json`**: Replaced inline postinstall command with `node scripts/postinstall.js`
- **`CONTRIBUTING.md`**: Added Windows prerequisites note in Getting Started section

On Windows without prerequisites, `npm install` now succeeds with a warning instead of failing. Users can install prerequisites and run `npm run rebuild-pty` afterwards.

## Testing

- Tested on macOS — all steps work correctly
- All 395 existing tests pass
- Prettier formatting clean