### PR TITLE
feat: show informative message when CLI is missing or user not logged in (#355)

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -459,6 +459,26 @@ const electronAPI = {
       ipcRenderer.on('copilot:error', handler);
       return () => ipcRenderer.removeListener('copilot:error', handler);
     },
+    onInitError: (
+      callback: (data: {
+        status: 'cli_not_found' | 'auth_failed' | 'unknown';
+        title: string;
+        message: string;
+        instructions: string[];
+      }) => void
+    ): (() => void) => {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        data: {
+          status: 'cli_not_found' | 'auth_failed' | 'unknown';
+          title: string;
+          message: string;
+          instructions: string[];
+        }
+      ): void => callback(data);
+      ipcRenderer.on('copilot:initError', handler);
+      return () => ipcRenderer.removeListener('copilot:initError', handler);
+    },
     onModelsVerified: (
       callback: (data: { models: { id: string; name: string; multiplier: number }[] }) => void
     ): (() => void) => {


### PR DESCRIPTION
## Summary

Closes #355

When the Copilot CLI is not found or authentication fails, Cooper now shows a clear error screen instead of a blank/broken UI.

## Changes

- **`src/main/main.ts`**: Enhanced `initCopilot` error handling — detects CLI not found (ENOENT/spawn errors), auth failures (401/token errors), and sends structured `copilot:initError` event
- **`src/preload/preload.ts`**: Added `onInitError` IPC listener for the new channel
- **`src/renderer/App.tsx`**: Added `initError` state and a full-screen error banner showing:
  - Emoji icon (🔍 for CLI, 🔐 for auth, ⚠️ for unknown)
  - Clear title and description
  - Step-by-step instructions to fix
  - Retry button

## Testing

- All 395 existing tests pass
- Prettier formatting clean