### PR TITLE
feat: improve Ralph Wiggum loop with stricter verification (#41)

### DIFF
--- a/src/renderer/types/session.ts
+++ b/src/renderer/types/session.ts
@@ -130,6 +130,8 @@ export interface RalphConfig {
   active: boolean;
   requireScreenshot?: boolean; // When true, agent must take screenshot of delivered feature
   clearContextBetweenIterations?: boolean; // When true, clears chat history each iteration (like Gemini Ralph)
+  requireBuildCheck?: boolean; // When true, agent must run build and verify 0 errors before completion
+  requireTests?: boolean; // When true, agent must add/run tests for new functionality
   startedAt?: string; // ISO timestamp of when loop started
   progressFilePath?: string; // Path to ralph-progress.md
   stateFilePath?: string; // Path to ralph-state.json for persistence


### PR DESCRIPTION
## Summary

Closes #41

The Ralph Wiggum loop now enforces stricter completion requirements and sends full iteration output to the agent for better continuity.

## Changes

### Full Agent Output Feedback
- Collects ALL assistant messages from the current iteration (not just the last one)
- Feeds the complete output back in the continuation prompt (up to 4000 chars in clear-context mode, unlimited in traditional mode)
- Agent can now see exactly what it did/said in the previous iteration

### New Configurable Requirements
- **Require build verification** (default: ON): Agent must run `npm run build` and achieve 0 errors before signaling completion
- **Require tests** (default: ON): Agent must add/run tests for new functionality before completion
- Both show as UI toggles in Ralph settings panel with '(recommended)' label

### Stricter Plan Verification
- Progress file template now includes a plan checklist section
- Agent instructed to go through EVERY plan item individually (not just 'check them off')
- Final verification step requires going through each item ONE MORE TIME
- Explicit warning: 'DO NOT signal completion unless you have ACTUALLY VERIFIED each item'
- Continuation prompts list remaining items, not just next steps

### Existing Improvements Preserved
- Clear context mode (Gemini-style) with file-based state
- Screenshot requirement toggle
- Iteration-based progress tracking

## Testing
- All 395 existing tests pass
- Prettier formatting clean