### PR TITLE
feat: add terminal font configuration (#297)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -174,7 +174,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -540,7 +539,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -584,7 +582,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -628,7 +625,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1052,6 +1048,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1073,6 +1070,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1089,6 +1087,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1103,6 +1102,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2561,7 +2561,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2754,7 +2755,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2766,7 +2766,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3497,7 +3496,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4269,7 +4267,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4634,7 +4633,6 @@
       "integrity": "sha512-ce4Ogns4VMeisIuCSK0C62umG0lFy012jd8LMZ6w/veHUeX4fqfDrGe+HTWALAEwK6JwKP+dhPvizhArSOsFbg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.4.0",
         "builder-util": "26.3.4",
@@ -4742,7 +4740,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-prop": {
       "version": "10.1.0",
@@ -4878,7 +4877,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^18.11.18",
@@ -5092,6 +5090,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5112,6 +5111,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6660,7 +6660,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6689,7 +6688,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -7360,6 +7358,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9377,7 +9376,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9528,6 +9526,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -9545,6 +9544,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -9571,6 +9571,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9586,6 +9587,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9702,7 +9704,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9715,7 +9716,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9729,7 +9729,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -10035,6 +10036,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -10854,6 +10856,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -10917,6 +10920,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -11025,7 +11029,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11164,7 +11167,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -11940,7 +11942,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -12557,7 +12558,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12571,7 +12571,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4781,6 +4781,28 @@ ipcMain.handle('theme:listExternal', () => {
   return loadExternalThemes();
 });
 
+// Terminal font settings
+ipcMain.handle('terminal:getFontFamily', () => {
+  return (
+    (store.get('terminalFontFamily') as string) ||
+    'Menlo, Monaco, Consolas, "Courier New", monospace'
+  );
+});
+
+ipcMain.handle('terminal:setFontFamily', (_event, family: string) => {
+  store.set('terminalFontFamily', family);
+  return { success: true };
+});
+
+ipcMain.handle('terminal:getFontSize', () => {
+  return (store.get('terminalFontSize') as number) || 13;
+});
+
+ipcMain.handle('terminal:setFontSize', (_event, size: number) => {
+  store.set('terminalFontSize', Math.max(8, Math.min(24, size)));
+  return { success: true };
+});
+
 ipcMain.handle('theme:import', async () => {
   const result = await dialog.showOpenDialog(mainWindow!, {
     properties: ['openFile'],

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -892,6 +892,21 @@ const electronAPI = {
       return () => ipcRenderer.removeListener('theme:systemChanged', handler);
     },
   },
+  // Terminal settings
+  terminal: {
+    getFontFamily: (): Promise<string> => {
+      return ipcRenderer.invoke('terminal:getFontFamily');
+    },
+    setFontFamily: (family: string): Promise<{ success: boolean }> => {
+      return ipcRenderer.invoke('terminal:setFontFamily', family);
+    },
+    getFontSize: (): Promise<number> => {
+      return ipcRenderer.invoke('terminal:getFontSize');
+    },
+    setFontSize: (size: number): Promise<{ success: boolean }> => {
+      return ipcRenderer.invoke('terminal:setFontSize', size);
+    },
+  },
   // MCP Server Management
   mcp: {
     getConfig: (): Promise<{ mcpServers: Record<string, MCPServerConfig> }> => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -462,6 +462,12 @@ const App: React.FC = () => {
     return saved !== null ? saved === 'true' : true; // Default to enabled
   });
 
+  // Terminal font settings
+  const [terminalFontFamily, setTerminalFontFamily] = useState(
+    'Menlo, Monaco, Consolas, "Courier New", monospace'
+  );
+  const [terminalFontSize, setTerminalFontSize] = useState(13);
+
   // Welcome wizard state
   const [showWelcomeWizard, setShowWelcomeWizard] = useState(false);
   const [shouldShowWizardWhenReady, setShouldShowWizardWhenReady] = useState(false);
@@ -1263,6 +1269,16 @@ const App: React.FC = () => {
 
       // Don't load messages here - sessions are still pending resumption
       // The copilot:sessionResumed handler below will load messages when each session is actually ready
+
+      // Load terminal font settings
+      window.electronAPI.terminal
+        .getFontFamily()
+        .then(setTerminalFontFamily)
+        .catch(() => {});
+      window.electronAPI.terminal
+        .getFontSize()
+        .then(setTerminalFontSize)
+        .catch(() => {});
 
       // Mark data as loaded for wizard
       setDataLoaded(true);
@@ -5153,6 +5169,8 @@ Only when ALL the above are verified complete, output exactly: ${RALPH_COMPLETIO
                     })
                   }
                   onSendToAgent={handleSendTerminalOutput}
+                  fontFamily={terminalFontFamily}
+                  fontSize={terminalFontSize}
                 />
               ))}
 
@@ -7837,6 +7855,16 @@ Only when ALL the above are verified complete, output exactly: ${RALPH_COMPLETIO
             } catch (error) {
               console.error('Failed to reveal crash dumps path:', error);
             }
+          }}
+          terminalFontFamily={terminalFontFamily}
+          terminalFontSize={terminalFontSize}
+          onTerminalFontFamilyChange={(family) => {
+            setTerminalFontFamily(family);
+            window.electronAPI.terminal.setFontFamily(family).catch(() => {});
+          }}
+          onTerminalFontSizeChange={(size) => {
+            setTerminalFontSize(size);
+            window.electronAPI.terminal.setFontSize(size).catch(() => {});
           }}
         />
 

--- a/src/renderer/components/SettingsModal/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal/SettingsModal.tsx
@@ -19,7 +19,14 @@ import { useTheme } from '../../context/ThemeContext';
 import { trackEvent, TelemetryEvents } from '../../utils/telemetry';
 import { VOICE_KEYWORDS } from '../../hooks/useVoiceSpeech';
 
-type SettingsSection = 'themes' | 'voice' | 'sounds' | 'commands' | 'accessibility' | 'diagnostics';
+type SettingsSection =
+  | 'themes'
+  | 'voice'
+  | 'sounds'
+  | 'commands'
+  | 'accessibility'
+  | 'terminal'
+  | 'diagnostics';
 
 export interface SettingsModalProps {
   isOpen: boolean;
@@ -60,6 +67,11 @@ export interface SettingsModalProps {
   diagnosticsPaths?: { logFilePath: string; crashDumpsPath: string } | null;
   onRevealLogFile?: (path: string) => Promise<void>;
   onOpenCrashDumps?: (path: string) => Promise<void>;
+  // Terminal settings
+  terminalFontFamily?: string;
+  terminalFontSize?: number;
+  onTerminalFontFamilyChange?: (family: string) => void;
+  onTerminalFontSizeChange?: (size: number) => void;
 }
 
 export const SettingsModal: React.FC<SettingsModalProps> = ({
@@ -100,6 +112,10 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   diagnosticsPaths = null,
   onRevealLogFile,
   onOpenCrashDumps,
+  terminalFontFamily = 'Menlo, Monaco, Consolas, "Courier New", monospace',
+  terminalFontSize = 13,
+  onTerminalFontFamilyChange,
+  onTerminalFontSizeChange,
 }) => {
   const [activeSection, setActiveSection] = useState<SettingsSection>('themes');
   const [newCommandValue, setNewCommandValue] = useState('');
@@ -116,6 +132,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
     { id: 'themes', label: 'Themes', icon: <PaletteIcon size={16} /> },
     { id: 'accessibility', label: 'Accessibility', icon: <MonitorIcon size={16} /> },
     { id: 'commands', label: 'Commands', icon: <GlobeIcon size={16} /> },
+    { id: 'terminal', label: 'Terminal', icon: <MonitorIcon size={16} /> },
     { id: 'voice', label: 'Voice', icon: <MicIcon size={16} /> },
     { id: 'sounds', label: 'Sounds', icon: <VolumeIcon size={16} /> },
     { id: 'diagnostics', label: 'Diagnostics', icon: <WarningIcon size={16} /> },
@@ -614,6 +631,70 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
       </div>
     );
   };
+
+  const renderTerminalSection = () => (
+    <div>
+      <h4 className="text-[11px] font-semibold uppercase tracking-wider text-copilot-text-muted mb-1">
+        Terminal Font
+      </h4>
+      <p className="text-xs text-copilot-text-muted mb-3">
+        Customize the embedded terminal appearance.
+      </p>
+      <div className="space-y-3">
+        <div>
+          <label className="text-xs text-copilot-text mb-1 block">Font Family</label>
+          <input
+            type="text"
+            value={terminalFontFamily}
+            onChange={(e) => onTerminalFontFamilyChange?.(e.target.value)}
+            className="w-full px-2 py-1.5 text-xs bg-copilot-surface border border-copilot-border rounded text-copilot-text"
+            placeholder='Menlo, Monaco, Consolas, "Courier New", monospace'
+          />
+        </div>
+        <div>
+          <label className="text-xs text-copilot-text mb-1 block">
+            Font Size: {terminalFontSize}px
+          </label>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => onTerminalFontSizeChange?.(Math.max(8, terminalFontSize - 1))}
+              className="px-2 py-1 text-xs bg-copilot-surface border border-copilot-border rounded hover:bg-copilot-border text-copilot-text"
+            >
+              <MinusIcon size={12} />
+            </button>
+            <input
+              type="range"
+              min={8}
+              max={24}
+              value={terminalFontSize}
+              onChange={(e) => onTerminalFontSizeChange?.(parseInt(e.target.value))}
+              className="flex-1"
+            />
+            <button
+              onClick={() => onTerminalFontSizeChange?.(Math.min(24, terminalFontSize + 1))}
+              className="px-2 py-1 text-xs bg-copilot-surface border border-copilot-border rounded hover:bg-copilot-border text-copilot-text"
+            >
+              <PlusIcon size={12} />
+            </button>
+          </div>
+        </div>
+        <div
+          className="mt-3 p-3 rounded border border-copilot-border"
+          style={{
+            fontFamily: terminalFontFamily,
+            fontSize: `${terminalFontSize}px`,
+            backgroundColor: '#1e1e1e',
+            color: '#d4d4d4',
+          }}
+        >
+          <div>$ echo &quot;Preview&quot;</div>
+          <div>Preview</div>
+          <div>$ _</div>
+        </div>
+      </div>
+    </div>
+  );
+
   const renderDiagnosticsSection = () => (
     <div>
       <h4 className="text-[11px] font-semibold uppercase tracking-wider text-copilot-text-muted mb-1">
@@ -673,6 +754,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
         return renderAccessibilitySection();
       case 'commands':
         return renderCommandsSection();
+      case 'terminal':
+        return renderTerminalSection();
       case 'voice':
         return renderVoiceSection();
       case 'sounds':

--- a/src/renderer/components/Terminal/TerminalPanel.tsx
+++ b/src/renderer/components/Terminal/TerminalPanel.tsx
@@ -16,6 +16,8 @@ interface TerminalPanelProps {
   isOpen: boolean;
   onClose: () => void;
   onSendToAgent: (output: string, lineCount: number, lastCommandStart?: number) => void;
+  fontFamily?: string;
+  fontSize?: number;
 }
 
 export const TerminalPanel: React.FC<TerminalPanelProps> = ({
@@ -24,6 +26,8 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = ({
   isOpen,
   onClose,
   onSendToAgent,
+  fontFamily = 'Menlo, Monaco, Consolas, "Courier New", monospace',
+  fontSize = 13,
 }) => {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<XTerm | null>(null);
@@ -49,8 +53,8 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = ({
 
     const xterm = new XTerm({
       cursorBlink: true,
-      fontSize: 13,
-      fontFamily: 'Menlo, Monaco, Consolas, "Courier New", monospace',
+      fontSize,
+      fontFamily,
       theme: {
         background: 'var(--copilot-terminal-bg, #1e1e1e)',
         foreground: 'var(--copilot-terminal-text, #d4d4d4)',
@@ -345,6 +349,15 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = ({
       fitAddonRef.current.fit();
     }
   }, [terminalHeight, isResizing]);
+
+  // Update terminal font when settings change
+  useEffect(() => {
+    const xterm = xtermRef.current;
+    if (!xterm) return;
+    xterm.options.fontFamily = fontFamily;
+    xterm.options.fontSize = fontSize;
+    fitAddonRef.current?.fit();
+  }, [fontFamily, fontSize]);
 
   return (
     <div


### PR DESCRIPTION
Closes #297

Adds a Terminal section to Settings modal with configurable font family and font size. Settings persist via electron-store and apply immediately to open terminals.

- Font family: text input with fallback stack
- Font size: slider (8-24px) with +/- buttons  
- Live preview panel in settings
- Full IPC pipeline: main handlers → preload → App.tsx → TerminalPanel

All 395 tests pass.