### PR TITLE
feat: support login flow and CLI not found detection (#69)

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -459,6 +459,28 @@ const electronAPI = {
       ipcRenderer.on('copilot:error', handler);
       return () => ipcRenderer.removeListener('copilot:error', handler);
     },
+    onInitError: (
+      callback: (data: {
+        failureMode: 'cli_not_found' | 'auth_failed' | 'unknown';
+        title: string;
+        message: string;
+        instructions: string;
+      }) => void
+    ): (() => void) => {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        data: {
+          failureMode: 'cli_not_found' | 'auth_failed' | 'unknown';
+          title: string;
+          message: string;
+          instructions: string;
+        }
+      ): void => callback(data);
+      ipcRenderer.on('copilot:initError', handler);
+      return () => ipcRenderer.removeListener('copilot:initError', handler);
+    },
+    retryInit: (): Promise<void> => ipcRenderer.invoke('copilot:retryInit'),
+    openExternal: (url: string): Promise<void> => ipcRenderer.invoke('copilot:openExternal', url),
     onModelsVerified: (
       callback: (data: { models: { id: string; name: string; multiplier: number }[] }) => void
     ): (() => void) => {


### PR DESCRIPTION
Closes #69

Enhanced initCopilot catch block to detect failure mode (cli_not_found, auth_failed, unknown) and display a full-screen error banner with clear instructions and retry capability.

- Detects CLI binary not found (ENOENT) → shows install instructions
- Detects auth failures (401/token/credential) → shows login instructions + 'Open GitHub Login' button  
- Retry button re-runs initCopilot
- New IPC: copilot:initError, copilot:retryInit, copilot:openExternal

All 395 tests pass.