### PR TITLE
fix: disable spellcheck to remove red squiggly underlines (#75)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2144,6 +2144,7 @@ function createWindow(): void {
       nodeIntegration: false,
       sandbox: false,
       webSecurity: true,
+      spellcheck: false,
     },
   });
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6153,6 +6153,7 @@ Only when ALL the above are verified complete, output exactly: ${RALPH_COMPLETIO
                     className="flex-1 bg-transparent py-2.5 pl-3 pr-2 text-copilot-text placeholder-copilot-text-muted outline-none text-sm resize-none min-h-[40px] max-h-[200px]"
                     disabled={status !== 'connected'}
                     autoFocus
+                    spellCheck={false}
                     rows={1}
                     style={{ height: 'auto' }}
                     onInput={(e) => {


### PR DESCRIPTION
Closes #75

Disables browser spellcheck on the chat textarea and in Electron webPreferences to remove misleading red squiggly underlines on code/technical content.

All 395 tests pass.