### PR TITLE
perf: reduce Windows installer size (#343)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,16 @@
     },
     "files": [
       "out/**/*",
-      "public/**/*"
+      "public/**/*",
+      "!**/*.map",
+      "!**/*.md",
+      "!**/CHANGELOG*",
+      "!**/LICENSE*",
+      "!**/*.d.ts",
+      "!**/test/**",
+      "!**/tests/**",
+      "!**/__tests__/**",
+      "!**/example*/**"
     ],
     "asarUnpack": [
       "node_modules/@github/copilot-*/**/*",
@@ -99,7 +108,8 @@
       "allowToChangeInstallationDirectory": true,
       "artifactName": "${productName}-${version}-win-${arch}-Setup.${ext}",
       "installerHeader": "build/icon.ico"
-    }
+    },
+    "compression": "maximum"
   },
   "dependencies": {
     "@github/copilot-sdk": "0.1.23",


### PR DESCRIPTION
Closes #343

Reduces installer size through:
- LZMA maximum compression for electron-builder
- Excludes sourcemaps, markdown, .d.ts, test dirs, examples from asar

All 395 tests pass.