### PR TITLE
feat: auto-close GitHub issue on worktree merge (#93)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4262,6 +4262,22 @@ ipcMain.handle(
   }
 );
 
+// Close a GitHub issue via gh CLI
+ipcMain.handle('git:closeGitHubIssue', async (_event, data: { issueUrl: string; cwd: string }) => {
+  try {
+    const match = data.issueUrl.match(/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/);
+    if (!match) return { success: false, error: 'Invalid GitHub issue URL' };
+    const [, owner, repo, number] = match;
+    await execAsync(
+      `gh issue close ${number} --repo "${owner}/${repo}" --comment "Closed via Cooper merge"`,
+      { cwd: data.cwd }
+    );
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: String(error) };
+  }
+});
+
 // Git operations - create pull request via gh CLI
 ipcMain.handle(
   'git:createPullRequest',

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -695,6 +695,12 @@ const electronAPI = {
         untrackedFiles,
       });
     },
+    closeGitHubIssue: (
+      issueUrl: string,
+      cwd: string
+    ): Promise<{ success: boolean; error?: string }> => {
+      return ipcRenderer.invoke('git:closeGitHubIssue', { issueUrl, cwd });
+    },
     createPullRequest: (
       cwd: string,
       title: string | undefined,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3641,6 +3641,7 @@ Only when ALL the above are verified complete, output exactly: ${RALPH_COMPLETIO
         currentIntentTimestamp: null,
         gitBranchRefresh: 0,
         yoloMode: autoStart?.yoloMode || false,
+        githubIssueUrl: autoStart?.issueInfo?.url,
         activeAgentName: undefined,
       };
       setTabs((prev) => [...prev, newTab]);

--- a/src/renderer/features/git/useCommitModal.ts
+++ b/src/renderer/features/git/useCommitModal.ts
@@ -401,6 +401,17 @@ export function useCommitModal(): UseCommitModalReturn {
           activeTab.untrackedFiles || []
         );
         if (result.success) {
+          // If this session was started from a GitHub issue, offer to close it
+          if (activeTab.githubIssueUrl) {
+            try {
+              await window.electronAPI.git.closeGitHubIssue(
+                activeTab.githubIssueUrl,
+                activeTab.cwd
+              );
+            } catch {
+              // Ignore close errors — issue may already be closed or gh not authed
+            }
+          }
           if (removeWorktreeAfterMerge && activeTab.cwd.includes('.copilot-sessions')) {
             const sessionId = activeTab.cwd.split(/[/\\]/).pop() || '';
             if (sessionId) {

--- a/src/renderer/types/session.ts
+++ b/src/renderer/types/session.ts
@@ -223,4 +223,5 @@ export interface TabState {
   markedForReview?: boolean; // Whether session is marked for follow-up review
   reviewNote?: string; // Optional user note displayed at bottom of conversation
   yoloMode?: boolean; // Auto-approve all permission requests without prompting
+  githubIssueUrl?: string; // GitHub issue URL if session was started from an issue
 }


### PR DESCRIPTION
Closes #93

Auto-closes the linked GitHub issue when a worktree branch is merged to main. Uses `gh issue close` via IPC.

- githubIssueUrl stored on TabState when created from issue
- git:closeGitHubIssue IPC handler
- Silent close after successful merge

All 395 tests pass.