### PR TITLE
feat: add Linux build releases and complete CI matrix (#272, #351)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,8 @@ jobs:
             platform: mac
           - os: windows-latest
             platform: win
+          - os: ubuntu-latest
+            platform: linux
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -136,6 +138,17 @@ jobs:
         run: |
           node node_modules/ffmpeg-static/install.js
           node node_modules/vosk-koffi/scripts/postinstall.js
+
+      # --- Linux setup ---
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: npm ci --ignore-scripts && npx patch-package && npm run rebuild-pty
+
+      - name: Install native dependency binaries (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          node node_modules/ffmpeg-static/install.js
+          node node_modules/vosk-koffi/scripts/postinstall.js || true
 
       # --- macOS code signing ---
       - name: Import code signing certificate
@@ -184,6 +197,10 @@ jobs:
           AZURE_CODE_SIGNING_ACCOUNT: ${{ secrets.AZURE_CODE_SIGNING_ACCOUNT }}
           AZURE_CERT_PROFILE: ${{ secrets.AZURE_CERT_PROFILE }}
 
+      - name: Build distributables (Linux)
+        if: runner.os == 'Linux'
+        run: npx electron-builder --linux --publish never
+
       - name: Upload DMG (macOS)
         if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
@@ -202,6 +219,14 @@ jobs:
           if-no-files-found: error
           retention-days: 5
 
+      - name: Upload AppImage (Linux)
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Cooper-AppImage
+          path: release/*.AppImage
+          if-no-files-found: error
+          retention-days: 5
 
   # ---------------------------------------------------------------------------
   # Job 3: Create GitHub Release with artifacts

--- a/package.json
+++ b/package.json
@@ -99,6 +99,25 @@
       "allowToChangeInstallationDirectory": true,
       "artifactName": "${productName}-${version}-win-${arch}-Setup.${ext}",
       "installerHeader": "build/icon.ico"
+    },
+    "linux": {
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "deb",
+          "arch": [
+            "x64"
+          ]
+        }
+      ],
+      "category": "Development",
+      "icon": "build/icon.png",
+      "artifactName": "${productName}-${version}-linux-${arch}.${ext}"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Closes #272, closes #351

Adds Linux to the release workflow build matrix. Builds AppImage and .deb packages. Also adds linux config to electron-builder.

All 395 tests pass.