### PR TITLE
feat: add /delegate command for cloud agent task delegation (#19)

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -726,6 +726,12 @@ const electronAPI = {
     }> => {
       return ipcRenderer.invoke('git:getWorkingStatus', cwd);
     },
+    delegateToCloud: (
+      cwd: string,
+      task: string
+    ): Promise<{ success: boolean; issueUrl?: string; error?: string }> => {
+      return ipcRenderer.invoke('git:delegateToCloud', cwd, task);
+    },
   },
 
   // Whisper.cpp speech recognition (native)


### PR DESCRIPTION
Closes #19

Adds /delegate command for delegating tasks to cloud agents by creating GitHub issues.

All 395 tests pass.