### PR TITLE
fix: pass windowRef to closePty to prevent PTY process leak

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5680,7 +5680,7 @@ ipcMain.handle('pty:clearBuffer', async (_event, sessionId: string) => {
 });
 
 ipcMain.handle('pty:close', async (_event, sessionId: string) => {
-  return ptyManager.closePty(sessionId);
+  return ptyManager.closePty(sessionId, mainWindow);
 });
 
 ipcMain.handle('pty:exists', async (_event, sessionId: string) => {

--- a/src/main/pty.ts
+++ b/src/main/pty.ts
@@ -470,7 +470,7 @@ export function createPty(
 ): { success: boolean; error?: string } {
   // Close existing PTY for this session if any
   if (ptyInstances.has(sessionId)) {
-    closePty(sessionId);
+    closePty(sessionId, mainWindow);
   }
 
   try {
@@ -603,14 +603,17 @@ export function clearPtyBuffer(sessionId: string): { success: boolean; error?: s
 }
 
 // Close PTY
-export function closePty(sessionId: string): { success: boolean; error?: string } {
+export function closePty(
+  sessionId: string,
+  windowRef: BrowserWindow | null = null
+): { success: boolean; error?: string } {
   const instance = ptyInstances.get(sessionId);
   if (!instance) {
     return { success: true }; // Already closed
   }
 
   try {
-    flushBatchBuffer(instance, sessionId, mainWindow);
+    flushBatchBuffer(instance, sessionId, windowRef);
     instance.pty.kill();
     ptyInstances.delete(sessionId);
     return { success: true };


### PR DESCRIPTION
## Problem

\closePty()\ called \lushBatchBuffer(instance, sessionId, mainWindow)\ but \mainWindow\ is not in scope at module level — it's only a parameter of \createPty()\.

At runtime, this threw \ReferenceError: mainWindow is not defined\. The error was caught silently, but \instance.pty.kill()\ was **skipped**, leaking the underlying shell process on every terminal close. Orphaned PowerShell processes accumulated and caused session hangs.

Introduced by commit \7b1c6f0\ (\	est: strengthen perf guardrails\) which extracted \lushBatchedData\ from a closure into a module-level function but incorrectly updated \closePty\.

## Fix

- Add optional \windowRef: BrowserWindow | null = null\ parameter to \closePty()\
- Replace \mainWindow\ with \windowRef\ in the function body
- Update \createPty()\'s internal call to pass \mainWindow\
- Update \pty:close\ IPC handler in \main.ts\ to pass \mainWindow\

\closeAllPtys()\ is unaffected — it calls \closePty(sessionId)\ with no second arg, defaulting to \
ull\, which is correct (no window to flush to on app quit).

## Testing

- \
px tsc --noEmit\ no longer reports \TS2304: Cannot find name 'mainWindow'\ in \pty.ts\
- All 225 unit tests pass (\
pm run test:components\)