### PR TITLE
fix: detect and abort stalled tool executions; upgrade SDK to 0.1.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@github/copilot-sdk": "^0.1.25",
+        "@github/copilot-sdk": "^0.1.29",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "electron-log": "^5.4.3",
@@ -1581,26 +1581,26 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-0.0.411.tgz",
-      "integrity": "sha512-I3/7gw40Iu1O+kTyNPKJHNqDRyOebjsUW6wJsvSVrOpT0TNa3/lfm8xdS2XUuJWkp+PgEG/PRwF7u3DVNdP7bQ==",
+      "version": "0.0.420",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-0.0.420.tgz",
+      "integrity": "sha512-UpPuSjxUxQ+j02WjZEFffWf0scLb23LvuGHzMFtaSsweR+P/BdbtDUI5ZDIA6T0tVyyt6+X1/vgfsJiRqd6jig==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "0.0.411",
-        "@github/copilot-darwin-x64": "0.0.411",
-        "@github/copilot-linux-arm64": "0.0.411",
-        "@github/copilot-linux-x64": "0.0.411",
-        "@github/copilot-win32-arm64": "0.0.411",
-        "@github/copilot-win32-x64": "0.0.411"
+        "@github/copilot-darwin-arm64": "0.0.420",
+        "@github/copilot-darwin-x64": "0.0.420",
+        "@github/copilot-linux-arm64": "0.0.420",
+        "@github/copilot-linux-x64": "0.0.420",
+        "@github/copilot-win32-arm64": "0.0.420",
+        "@github/copilot-win32-x64": "0.0.420"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-0.0.411.tgz",
-      "integrity": "sha512-dtr+iHxTS4f8HlV2JT9Fp0FFoxuiPWCnU3XGmrHK+rY6bX5okPC2daU5idvs77WKUGcH8yHTZtfbKYUiMxKosw==",
+      "version": "0.0.420",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-0.0.420.tgz",
+      "integrity": "sha512-sj8Oxcf3oKDbeUotm2gtq5YU1lwCt3QIzbMZioFD/PMLOeqSX/wrecI+c0DDYXKofFhALb0+DxxnWgbEs0mnkQ==",
       "cpu": [
         "arm64"
       ],
@@ -1614,9 +1614,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-0.0.411.tgz",
-      "integrity": "sha512-zhdbQCbPi1L4iHClackSLx8POfklA+NX9RQLuS48HlKi/0KI/JlaDA/bdbIeMR79wjif5t9gnc/m+RTVmHlRtA==",
+      "version": "0.0.420",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-0.0.420.tgz",
+      "integrity": "sha512-2acA93IqXz1uuz3TVUm0Y7BVrBr0MySh1kQa8LqMILhTsG0YHRMm8ybzTp2HA7Mi1tl5CjqMSk163kkS7OzfUA==",
       "cpu": [
         "x64"
       ],
@@ -1630,9 +1630,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-0.0.411.tgz",
-      "integrity": "sha512-oZYZ7oX/7O+jzdTUcHkfD1A8YnNRW6mlUgdPjUg+5rXC43bwIdyatAnc0ObY21m9h8ghxGqholoLhm5WnGv1LQ==",
+      "version": "0.0.420",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-0.0.420.tgz",
+      "integrity": "sha512-h/IvEryTOYm1HzR2GNq8s2aDtN4lvT4MxldfZuS42CtWJDOfVG2jLLsoHWU1T3QV8j1++PmDgE//HX0JLpLMww==",
       "cpu": [
         "arm64"
       ],
@@ -1646,9 +1646,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-0.0.411.tgz",
-      "integrity": "sha512-nnXrKANmmGnkwa3ROlKdAhVNOx8daeMSE8Xh0o3ybKckFv4s38blhKdcxs0RJQRxgAk4p7XXGlDDKNRhurqF1g==",
+      "version": "0.0.420",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-0.0.420.tgz",
+      "integrity": "sha512-iL2NpZvXIDZ+3lw7sO2fo5T0nKmP5dZbU2gdYcv+SFBm/ONhCxIY5VRX4yN/9VkFaa9ePv5JzCnsl3vZINiDxg==",
       "cpu": [
         "x64"
       ],
@@ -1662,12 +1662,12 @@
       }
     },
     "node_modules/@github/copilot-sdk": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.1.25.tgz",
-      "integrity": "sha512-hIgYLPXzWw9bNgrsD5BLKmgVH20ow5Or5UyVXfVe3YgeiaTgFxC4jWSAVHLGB6ufHZUrvbjppcq2dWK63FmDRA==",
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.1.29.tgz",
+      "integrity": "sha512-GdcN6bJTeesr1HP6IrhN2MznIf1B3ufqd3PX+uKbDLXNriOmP65Ai29/hxzTidNLHyOf6rW4NwmFfkMXiKfCBw==",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^0.0.411",
+        "@github/copilot": "^0.0.420",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -1676,9 +1676,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-0.0.411.tgz",
-      "integrity": "sha512-h+Bovb2YVCQSeELZOO7zxv8uht45XHcvAkFbRsc1gf9dl109sSUJIcB4KAhs8Aznk28qksxz7kvdSgUWyQBlIA==",
+      "version": "0.0.420",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-0.0.420.tgz",
+      "integrity": "sha512-Njlc2j9vYSBAL+lC6FIEhQ3C+VxO3xavwKnw0ecVRiNLcGLyPrTdzPfPQOmEjC63gpVCqLabikoDGv8fuLPA2w==",
       "cpu": [
         "arm64"
       ],
@@ -1692,9 +1692,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-0.0.411.tgz",
-      "integrity": "sha512-xmOgi1lGvUBHQJWmq5AK1EP95+Y8xR4TFoK9OCSOaGbQ+LFcX2jF7iavnMolfWwddabew/AMQjsEHlXvbgMG8Q==",
+      "version": "0.0.420",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-0.0.420.tgz",
+      "integrity": "sha512-rZlH35oNehAP2DvQbu4vQFVNeCh/1p3rUjafBYaEY0Nkhx7RmdrYBileL5U3PtRPPRsBPaq3Qp+pVIrGoCDLzQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     }
   },
   "dependencies": {
-    "@github/copilot-sdk": "^0.1.25",
+    "@github/copilot-sdk": "^0.1.29",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "electron-log": "^5.4.3",


### PR DESCRIPTION
## Problem
When the Copilot backend drops the connection mid-turn (during tool execution), SDK 0.1.25 hangs silently forever — the session shows \	ool.execution_start\ but never \	ool.execution_complete\. The UI is permanently stuck and the user has no way to recover without closing the tab.

## Changes

### Stall detection (\src/main/main.ts\)
Added a 5-minute stall detector across all 4 session event handler paths:
- On \	ool.execution_start\ → starts a per-session timeout
- On \	ool.execution_complete\ → clears the timeout
- If the timeout fires → calls \session.abort()\, sends \copilot:error\ to the UI with the tool name, then sends \copilot:idle\ to unblock the session

This catches both truly hung commands and the backend-disconnect case.

### SDK upgrade (\package.json\)
Upgraded \@github/copilot-sdk\ from \