### PR TITLE
feat: switch to git-based updates and simplify PR checks

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  check:
     strategy:
       fail-fast: false
       matrix:
@@ -85,7 +85,7 @@ jobs:
           node node_modules/ffmpeg-static/install.js
           node node_modules/vosk-koffi/scripts/postinstall.js
 
-      # --- Build & package (no signing) ---
+      # --- Test & build (no packaging) ---
       - name: Run tests
         run: npm test
 
@@ -94,98 +94,3 @@ jobs:
 
       - name: Check bundle guardrail
         run: node scripts/check-bundle-size.js --compare-baseline
-
-      - name: Package distributables (macOS, unsigned)
-        if: runner.os == 'macOS'
-        run: npx electron-builder --mac --publish never
-        timeout-minutes: 15
-        env:
-          CSC_IDENTITY_AUTO_DISCOVERY: false
-
-      - name: Package distributables (Windows, unsigned)
-        if: runner.os == 'Windows'
-        run: npx electron-builder --win --publish never
-
-      - name: Package distributables (Linux)
-        if: runner.os == 'Linux'
-        run: npx electron-builder --linux --publish never
-
-      # --- Upload artifacts for reviewers to test ---
-      - name: Upload DMG (macOS)
-        if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Cooper-DMG
-          path: release/*.dmg
-          if-no-files-found: error
-          retention-days: 3
-
-      - name: Upload Installer (Windows)
-        if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Cooper-Setup
-          path: release/*-Setup.exe
-          if-no-files-found: error
-          retention-days: 3
-
-      - name: Upload AppImage (Linux)
-        if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Cooper-AppImage
-          path: release/*.AppImage
-          if-no-files-found: error
-          retention-days: 3
-
-      - name: Upload deb (Linux)
-        if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Cooper-deb
-          path: release/*.deb
-          if-no-files-found: error
-          retention-days: 3
-
-  # Fedora build to verify non-Debian distro compatibility
-  # Only builds AppImage to test compatibility - rpm would require libcrypt compat library
-  build-fedora:
-    runs-on: ubuntu-latest
-    container:
-      image: fedora:latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install system dependencies (Fedora)
-        run: |
-          dnf install -y nodejs npm git python3 make gcc gcc-c++
-          ./scripts/install-linux-deps.sh
-
-      - name: Install dependencies
-        run: npm ci --ignore-scripts && npx patch-package && npm run rebuild-pty
-
-      - name: Install native dependency binaries
-        run: |
-          node node_modules/ffmpeg-static/install.js
-          node node_modules/vosk-koffi/scripts/postinstall.js
-
-      - name: Run tests
-        run: npm test
-
-      - name: Build application
-        run: npm run prebuild-info && npx electron-vite build
-
-      - name: Check bundle guardrail
-        run: node scripts/check-bundle-size.js --compare-baseline
-
-      - name: Package AppImage (Fedora)
-        run: npx electron-builder --linux AppImage --publish never
-
-      - name: Upload AppImage (Fedora)
-        uses: actions/upload-artifact@v4
-        with:
-          name: Cooper-AppImage-fedora
-          path: release/*.AppImage
-          if-no-files-found: error
-          retention-days: 3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,13 +67,13 @@ node scripts/bump-version.js [major|minor|patch]
 
 ### Testing from a feature branch
 
-Open a PR to `staging`. The **Build Check** workflow will build and package the app on macOS and Windows (unsigned), and upload the artifacts. Download them from the PR's workflow run in the Actions tab — they're kept for 3 days.
+Open a PR to `staging`. The **Build Check** workflow will run tests, build the app, and check bundle sizes on macOS, Windows, and Linux.
 
 ## CI
 
 ### Pull request checks
 
-Every PR to `main` or `staging` runs the **Build Check** workflow (`.github/workflows/build-pr.yml`). It builds and packages the app on macOS and Windows — the same platforms as the release — but without code signing. Unsigned artifacts (DMG, Setup installer) are uploaded and kept for 3 days so reviewers can test the build. Doc-only changes (`*.md`, `docs/**`) are skipped.
+Every PR to `main` or `staging` runs the **Build Check** workflow (`.github/workflows/build-pr.yml`). It runs tests, builds the app with `electron-vite build`, and checks the bundle size guardrail on macOS, Windows, and Linux. Doc-only changes (`*.md`, `docs/**`) are skipped.
 
 ### Release workflow
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6013,47 +6013,21 @@ ipcMain.handle('diagnostics:getPaths', async () => {
 const GITHUB_REPO_OWNER = 'CooperAgent';
 const GITHUB_REPO_NAME = 'cooper';
 
-interface GitHubRelease {
-  tag_name: string;
-  name: string;
-  body: string;
-  html_url: string;
-  published_at: string;
-  prerelease: boolean;
-  assets: Array<{ name: string; browser_download_url: string }>;
-}
-
-// Check for updates from GitHub releases
+// Check for updates by comparing local version with package.json on main branch
 ipcMain.handle('updates:checkForUpdate', async () => {
   try {
-    // Fetch release list so we can skip non-semver tags (e.g. the "assets" release)
+    // Fetch package.json from the main branch to get the latest version
     const response = await fetch(
-      `https://api.github.com/repos/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/releases?per_page=10`,
-      {
-        headers: {
-          Accept: 'application/vnd.github.v3+json',
-          'User-Agent': 'Cooper',
-        },
-      }
+      `https://raw.githubusercontent.com/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/main/package.json`,
+      { headers: { 'User-Agent': 'Cooper' } }
     );
 
     if (!response.ok) {
-      if (response.status === 404) {
-        return { hasUpdate: false, error: 'No releases found' };
-      }
-      throw new Error(`GitHub API error: ${response.status}`);
+      throw new Error(`GitHub raw content error: ${response.status}`);
     }
 
-    const releases = (await response.json()) as GitHubRelease[];
-    // Find the first non-prerelease release with a semver tag
-    const semverRegex = /^v?\d+\.\d+\.\d+$/;
-    const release = releases.find((r) => !r.prerelease && semverRegex.test(r.tag_name));
-
-    if (!release) {
-      return { hasUpdate: false, error: 'No semver releases found' };
-    }
-
-    const latestVersion = release.tag_name.replace(/^v/, '');
+    const remotePkg = (await response.json()) as { version: string };
+    const latestVersion = remotePkg.version.split('+')[0].split('-')[0];
 
     // Get current version from package.json
     const pkgPath = join(__dirname, '..', '..', 'package.json');
@@ -6079,19 +6053,10 @@ ipcMain.handle('updates:checkForUpdate', async () => {
     // Compare versions (simple comparison, assumes semver)
     const hasUpdate = compareVersions(latestVersion, currentVersion) > 0;
 
-    // Pick a platform-appropriate download asset
-    const isWindows = process.platform === 'win32';
-    const installerAsset = release.assets.find((a) =>
-      isWindows ? a.name.endsWith('.exe') : a.name.endsWith('.dmg')
-    );
-
     return {
       hasUpdate: hasUpdate && latestVersion !== (store.get('dismissedUpdateVersion', '') as string),
       currentVersion,
       latestVersion,
-      releaseNotes: release.body || '',
-      releaseUrl: release.html_url,
-      downloadUrl: installerAsset?.browser_download_url || release.html_url,
     };
   } catch (error) {
     console.error('Failed to check for updates:', error);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1262,9 +1262,6 @@ const electronAPI = {
       hasUpdate: boolean;
       currentVersion?: string;
       latestVersion?: string;
-      releaseNotes?: string;
-      releaseUrl?: string;
-      downloadUrl?: string;
       error?: string;
     }> => {
       return ipcRenderer.invoke('updates:checkForUpdate');

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -470,7 +470,6 @@ const App: React.FC = () => {
   const [updateInfo, setUpdateInfo] = useState<{
     currentVersion: string;
     latestVersion: string;
-    downloadUrl: string;
   } | null>(null);
   const [showReleaseNotesModal, setShowReleaseNotesModal] = useState(false);
 
@@ -774,11 +773,10 @@ const App: React.FC = () => {
 
         // Check for newer updates available
         const updateResult = await window.electronAPI.updates.checkForUpdate();
-        if (updateResult.hasUpdate && updateResult.latestVersion && updateResult.downloadUrl) {
+        if (updateResult.hasUpdate && updateResult.latestVersion) {
           setUpdateInfo({
             currentVersion: updateResult.currentVersion || currentVersion,
             latestVersion: updateResult.latestVersion,
-            downloadUrl: updateResult.downloadUrl,
           });
           // Show update modal after release notes (if any) are dismissed
           if (!buildInfo.releaseNotes || lastSeenVersion === currentVersion) {
@@ -800,12 +798,10 @@ const App: React.FC = () => {
     (window as any).showUpdateModal = (info?: {
       currentVersion?: string;
       latestVersion?: string;
-      downloadUrl?: string;
     }) => {
       const defaults = {
         currentVersion: buildInfo.baseVersion,
         latestVersion: '99.0.0',
-        downloadUrl: 'https://github.com/CooperAgent/cooper/releases',
       };
       setUpdateInfo({ ...defaults, ...info });
       setShowUpdateModal(true);

--- a/src/renderer/components/UpdateAvailableModal/UpdateAvailableModal.tsx
+++ b/src/renderer/components/UpdateAvailableModal/UpdateAvailableModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Modal } from '../Modal';
 import { Button } from '../Button';
 
@@ -10,6 +10,8 @@ export interface UpdateAvailableModalProps {
   onDontRemind: () => void;
 }
 
+const UPDATE_COMMAND = 'git pull && npm run dist';
+
 export const UpdateAvailableModal: React.FC<UpdateAvailableModalProps> = ({
   isOpen,
   onClose,
@@ -17,15 +19,21 @@ export const UpdateAvailableModal: React.FC<UpdateAvailableModalProps> = ({
   newVersion,
   onDontRemind,
 }) => {
+  const [copied, setCopied] = useState(false);
+
   const handleDontRemind = () => {
     onDontRemind();
     onClose();
   };
 
-  const handleOpenReleases = () => {
-    window.electronAPI.updates.openDownloadUrl(
-      'https://github.com/CooperAgent/cooper/releases/latest'
-    );
+  const handleCopyCommand = async () => {
+    try {
+      await navigator.clipboard.writeText(UPDATE_COMMAND);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API may not be available
+    }
   };
 
   return (
@@ -71,8 +79,24 @@ export const UpdateAvailableModal: React.FC<UpdateAvailableModalProps> = ({
           </div>
 
           <p className="text-copilot-text-muted text-xs text-center">
-            Visit the releases page to download the latest version.
+            Run the following command in your Cooper directory to update:
           </p>
+
+          <div className="relative group">
+            <button
+              onClick={handleCopyCommand}
+              className="w-full bg-copilot-background rounded-lg p-3 font-mono text-sm text-copilot-text text-center cursor-pointer hover:bg-copilot-border/30 transition-colors"
+              title="Click to copy"
+              data-testid="copy-update-command"
+            >
+              {UPDATE_COMMAND}
+            </button>
+            <span
+              className={`absolute top-1 right-2 text-xs transition-opacity ${copied ? 'text-green-500 opacity-100' : 'text-copilot-text-muted opacity-0 group-hover:opacity-100'}`}
+            >
+              {copied ? 'Copied!' : 'Click to copy'}
+            </span>
+          </div>
         </div>
       </Modal.Body>
       <Modal.Footer className="p-4 border-t border-copilot-border">
@@ -81,8 +105,8 @@ export const UpdateAvailableModal: React.FC<UpdateAvailableModalProps> = ({
             <Button variant="ghost" onClick={onClose}>
               Later
             </Button>
-            <Button variant="primary" onClick={handleOpenReleases}>
-              Open Releases
+            <Button variant="primary" onClick={handleCopyCommand}>
+              {copied ? 'Copied!' : 'Copy Command'}
             </Button>
           </div>
           <div className="flex justify-center">

--- a/tests/components/UpdateModals.test.tsx
+++ b/tests/components/UpdateModals.test.tsx
@@ -4,16 +4,13 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { UpdateAvailableModal } from '../../src/renderer/components/UpdateAvailableModal';
 import { ReleaseNotesModal } from '../../src/renderer/components/ReleaseNotesModal';
 
-// Mock the electronAPI
-const mockOpenDownloadUrl = vi.fn();
+// Mock clipboard API
+const mockClipboardWriteText = vi.fn().mockResolvedValue(undefined);
 
 beforeEach(() => {
-  // @ts-expect-error - mocking electron API
-  window.electronAPI = {
-    updates: {
-      openDownloadUrl: mockOpenDownloadUrl,
-    },
-  };
+  Object.assign(navigator, {
+    clipboard: { writeText: mockClipboardWriteText },
+  });
 });
 
 describe('UpdateAvailableModal', () => {
@@ -47,6 +44,31 @@ describe('UpdateAvailableModal', () => {
     });
   });
 
+  it('displays the update command', async () => {
+    render(<UpdateAvailableModal {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText('git pull && npm run dist')).toBeInTheDocument();
+    });
+  });
+
+  it('copies command to clipboard when copy button is clicked', async () => {
+    render(<UpdateAvailableModal {...defaultProps} />);
+    await waitFor(() => expect(screen.getByText('Copy Command')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Copy Command'));
+    await waitFor(() => {
+      expect(mockClipboardWriteText).toHaveBeenCalledWith('git pull && npm run dist');
+    });
+  });
+
+  it('copies command when the command block is clicked', async () => {
+    render(<UpdateAvailableModal {...defaultProps} />);
+    await waitFor(() => expect(screen.getByTestId('copy-update-command')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('copy-update-command'));
+    await waitFor(() => {
+      expect(mockClipboardWriteText).toHaveBeenCalledWith('git pull && npm run dist');
+    });
+  });
+
   it('calls onClose when Later button is clicked', async () => {
     render(<UpdateAvailableModal {...defaultProps} />);
     await waitFor(() => expect(screen.getByText('Later')).toBeInTheDocument());
@@ -62,22 +84,6 @@ describe('UpdateAvailableModal', () => {
     fireEvent.click(screen.getByText("Don't remind me about this version"));
     expect(defaultProps.onDontRemind).toHaveBeenCalled();
     expect(defaultProps.onClose).toHaveBeenCalled();
-  });
-
-  it('opens releases page when Open Releases button is clicked', async () => {
-    render(<UpdateAvailableModal {...defaultProps} />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Open Releases')).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByText('Open Releases'));
-
-    await waitFor(() => {
-      expect(mockOpenDownloadUrl).toHaveBeenCalledWith(
-        'https://github.com/CooperAgent/cooper/releases/latest'
-      );
-    });
   });
 });
 


### PR DESCRIPTION
## Summary

Switches Cooper from GitHub Releases-based update checking to a simpler `package.json`-based approach, and simplifies PR CI since we no longer distribute packaged binaries.

## Changes

### Version check (`src/main/main.ts`)
- Now fetches `package.json` from `main` branch via `raw.githubusercontent.com` instead of querying the GitHub Releases API
- Removed `GitHubRelease` interface and release asset detection logic

### Update modal (`UpdateAvailableModal.tsx`)
- Replaced "Open Releases" button with a copyable `git pull && npm run dist` command
- Users click the command block or "Copy Command" button to copy to clipboard
- Removed dependency on `electronAPI.updates.openDownloadUrl`

### PR checks (`.github/workflows/build-pr.yml`)
- Removed all packaging steps (`electron-builder`), artifact uploads, and Fedora build job
- Keeps: tests, `electron-vite build`, and bundle size guardrail

### Cleanup
- Removed `downloadUrl`, `releaseUrl`, `releaseNotes` from update check response (preload + renderer)
- Updated `CONTRIBUTING.md` to reflect simplified PR checks

## Testing
- `npm test` — 493 tests pass
- `npm run build` — clean build
- `window.showUpdateModal()` in DevTools to preview the new modal