### PR TITLE
chore(sdk): bump staging to @github/copilot-sdk 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@github/copilot-sdk": "^0.2.1",
+        "@github/copilot-sdk": "^0.2.2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "electron-log": "^5.4.3",
@@ -177,7 +177,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -556,7 +555,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -597,7 +595,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -641,7 +638,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1065,6 +1061,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1086,6 +1083,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1102,6 +1100,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1116,6 +1115,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1581,26 +1581,26 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.18.tgz",
-      "integrity": "sha512-8IEJG+Cf9Xohp50PqezN4isqPYayZ9wOEmMTk5wTMq7O3ph9jPj4az2AlvR8Ib2baVk4gPIPL+VPIDqc1bBqHQ==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.24.tgz",
+      "integrity": "sha512-/nZ2GwhaGq0HeI3W+6LE0JGw25/bipC6tYVa+oQ5tIvAafBazuNt10CXkeaor+u9oBWLZtPbdTyAzE2tjy9NpQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.18",
-        "@github/copilot-darwin-x64": "1.0.18",
-        "@github/copilot-linux-arm64": "1.0.18",
-        "@github/copilot-linux-x64": "1.0.18",
-        "@github/copilot-win32-arm64": "1.0.18",
-        "@github/copilot-win32-x64": "1.0.18"
+        "@github/copilot-darwin-arm64": "1.0.24",
+        "@github/copilot-darwin-x64": "1.0.24",
+        "@github/copilot-linux-arm64": "1.0.24",
+        "@github/copilot-linux-x64": "1.0.24",
+        "@github/copilot-win32-arm64": "1.0.24",
+        "@github/copilot-win32-x64": "1.0.24"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.18.tgz",
-      "integrity": "sha512-GCpOAebNStehmO4hGhe7wvjp6+7BgVXUNP66yq4Y0GDx6fZ8Rsd+fIgS4Ta+5zX2FP589KpWcBEHMOZLdG1HkQ==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.24.tgz",
+      "integrity": "sha512-lejn6KV+09rZEICX3nRx9a58DQFQ2kK3NJ3EICfVLngUCWIUmwn1BLezjeTQc9YNasHltA1hulvfsWqX+VjlMw==",
       "cpu": [
         "arm64"
       ],
@@ -1614,9 +1614,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.18.tgz",
-      "integrity": "sha512-k4Xajwt69FQm4ovmQFP9WQUwhCx2xT3IQwb/0cAH5n8sY/hk6ZIfILZ1wrEdqFuDcGsQp3T+jzm2kybTlYd9qw==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.24.tgz",
+      "integrity": "sha512-r2F3keTvr4Bunz3V+waRAvsHgqsVQGyIZFBebsNPWxBX1eh3IXgtBqxCR7vXTFyZonQ8VaiJH3YYEfAhyKsk9g==",
       "cpu": [
         "x64"
       ],
@@ -1630,9 +1630,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.18.tgz",
-      "integrity": "sha512-giFA7cKxlYFBBz7DhYgfB4SQdOyu7YTUJ7rjmEnF5G6P2jvCyRW836JzP8yiq0pZKj7Ps/TQc4ba0+/gSbJXLA==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.24.tgz",
+      "integrity": "sha512-B3oANXKKKLhnKYozXa/W+DxfCQAHJCs0QKR5rBwNrwJbf656twNgALSxWTSJk+1rEP6MrHCswUAcwjwZL7Q+FQ==",
       "cpu": [
         "arm64"
       ],
@@ -1646,9 +1646,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.18.tgz",
-      "integrity": "sha512-ETFdAlAbQwO5OhvyE2aVUaVPJHj0aEWSzLF+XZ9uRK4vdpyGHu+DIQkSWEu0ttnELYbAsCryXqxj8n1QRQgcsQ==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.24.tgz",
+      "integrity": "sha512-NGTldizY54B+4Sfhu/GWoEQNMwqqUNgMwbSgBshFv+Hqy1EwuvNWKVov1Y0Vzhp4qAHc6ZxBk/OPIW8Ato9FUg==",
       "cpu": [
         "x64"
       ],
@@ -1662,12 +1662,12 @@
       }
     },
     "node_modules/@github/copilot-sdk": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.1.tgz",
-      "integrity": "sha512-S1n/4X1viqbSAWcHDZcFyZ/7hgTLAXr3NY7yNmHoX/CL4LTuYIJ6y5w2jrqUnrJNQgtNrMDSFGwFU+H1GeynFw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.2.tgz",
+      "integrity": "sha512-VZCqS08YlUM90bUKJ7VLeIxgTTEHtfXBo84T1IUMNvXRREX2csjPH6Z+CPw3S2468RcCLvzBXcc9LtJJTLIWFw==",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.17",
+        "@github/copilot": "^1.0.21",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -1676,9 +1676,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.18.tgz",
-      "integrity": "sha512-+ovxEz5weMHerm98whVZFn+ySVXRxSusaMa/UP/zQRRP5YKZcnfY1Jj5Majg5MN/kWcatTxxhPde9Thgr3feYw==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.24.tgz",
+      "integrity": "sha512-/pd/kgef7/HIIg1SQq4q8fext39pDSC44jHB10KkhfgG1WaDFhQbc/aSSMQfxeldkRbQh6VANp8WtGQdwtMCBA==",
       "cpu": [
         "arm64"
       ],
@@ -1692,9 +1692,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.18.tgz",
-      "integrity": "sha512-Uy6zDu2b02E4oKG8DYdYVmBDYpCvRMTlg8RIYj1PFBHpENxAkY71WOBabYpdQtrfiddRJZsGqi0YFoTeLGksVQ==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.24.tgz",
+      "integrity": "sha512-RDvOiSvyEJwELqErwANJTrdRuMIHkwPE4QK7Le7WsmaSKxiuS4H1Pa8Yxnd2FWrMsCHEbase23GJlymbnGYLXQ==",
       "cpu": [
         "x64"
       ],
@@ -2574,7 +2574,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2767,7 +2768,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2779,7 +2779,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3510,7 +3509,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4282,7 +4280,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4637,7 +4636,6 @@
       "integrity": "sha512-ce4Ogns4VMeisIuCSK0C62umG0lFy012jd8LMZ6w/veHUeX4fqfDrGe+HTWALAEwK6JwKP+dhPvizhArSOsFbg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.4.0",
         "builder-util": "26.3.4",
@@ -4745,7 +4743,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-prop": {
       "version": "10.1.0",
@@ -4881,7 +4880,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^18.11.18",
@@ -5095,6 +5093,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5115,6 +5114,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6717,7 +6717,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6746,7 +6745,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -7418,6 +7416,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9435,7 +9434,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9586,6 +9584,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -9603,6 +9602,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -9629,6 +9629,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9644,6 +9645,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9760,7 +9762,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9773,7 +9774,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9787,7 +9787,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -10093,6 +10094,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -10912,6 +10914,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -10975,6 +10978,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -11083,7 +11087,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11222,7 +11225,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -12008,7 +12010,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12586,7 +12587,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     }
   },
   "dependencies": {
-    "@github/copilot-sdk": "^0.2.1",
+    "@github/copilot-sdk": "^0.2.2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "electron-log": "^5.4.3",


### PR DESCRIPTION
## Summary
- add the PR #534 Copilot SDK bump to \
- keep \ as the source of truth and do not merge any later \ state back into it
- leave the branch as \ plus the 0.2.2 bump only

## Notes
- this branch is exactly \ plus commit \
- no merge-from-main commit is included
- \
> cooper@1.0.5 test
> vitest run


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/Users/idofrizler/.copilot-sessions/cooper--chore-sync-staging-and-main[39m

 [32m✓[39m tests/components/Modal.test.tsx [2m([22m[2m7 tests[22m[2m)[22m[32m 145[2mms[22m[39m
 [32m✓[39m tests/components/CreateWorktreeSession.test.tsx [2m([22m[2m7 tests[22m[2m)[22m[32m 86[2mms[22m[39m
 [32m✓[39m tests/components/AgentIcons.test.tsx [2m([22m[2m8 tests[22m[2m)[22m[32m 222[2mms[22m[39m
 [32m✓[39m tests/components/ChoiceSelector.test.tsx [2m([22m[2m7 tests[22m[2m)[22m[32m 230[2mms[22m[39m
 [32m✓[39m tests/components/YoloMode.test.tsx [2m([22m[2m7 tests[22m[2m)[22m[32m 181[2mms[22m[39m
 [32m✓[39m tests/components/Button.test.tsx [2m([22m[2m13 tests[22m[2m)[22m[32m 258[2mms[22m[39m
 [32m✓[39m tests/components/EnvironmentModal.test.tsx [2m([22m[2m4 tests[22m[2m)[22m[32m 86[2mms[22m[39m
 [32m✓[39m tests/components/UpdateModals.test.tsx [2m([22m[2m14 tests[22m[2m)[22m[32m 126[2mms[22m[39m
 [32m✓[39m tests/components/SearchableBranchSelect.test.tsx [2m([22m[2m13 tests[22m[2m)[22m[32m 273[2mms[22m[39m
 [32m✓[39m tests/components/CodeBlock.test.tsx [2m([22m[2m16 tests[22m[2m)[22m[33m 384[2mms[22m[39m
 [32m✓[39m src/main/worktree.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/main/instructions.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m tests/components/SettingsModalVoice.test.tsx [2m([22m[2m19 tests[22m[2m)[22m[33m 313[2mms[22m[39m
 [32m✓[39m src/main/agents.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/main/agents-mcp.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/main/mcpDiscovery.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m tests/components/FilePreviewEdit.test.tsx [2m([22m[2m12 tests[22m[2m)[22m[33m 712[2mms[22m[39m
 [32m✓[39m src/main/skills.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m tests/components/ChatInput.test.tsx [2m([22m[2m6 tests[22m[2m)[22m[33m 851[2mms[22m[39m
 [32m✓[39m tests/components/CommitModal.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 240[2mms[22m[39m
 [32m✓[39m tests/components/SessionHistory.test.tsx [2m([22m[2m35 tests[22m[2m)[22m[33m 1043[2mms[22m[39m
 [32m✓[39m src/renderer/utils/agentPicker.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m tests/components/useCommitModal.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/main/pty.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m tests/components/Spinner.test.tsx [2m([22m[2m6 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m src/main/utils/extractExecutables.test.ts [2m([22m[2m96 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/main/utils/throttle.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/main/mcpHandlers.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/main/mcpSessionConfig.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m tests/components/sourceIssuePrLink.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/renderer/utils/isAsciiDiagram.test.ts [2m([22m[2m24 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m tests/components/cliOutputCompression.test.ts [2m([22m[2m30 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m tests/components/TitleBar.test.tsx [2m([22m[2m5 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m tests/components/LisaLoop.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/renderer/utils/isCliCommand.test.ts [2m([22m[2m29 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/main/utils/modelSwitch.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/renderer/utils/parseGitHubIssueUrl.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m tests/components/telemetry.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/main/utils/sessionRestore.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m tests/components/extractLastRunFromLine.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/renderer/utils/primaryAgent.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/main/utils/permissionRequest.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/main/utils/toolStallHeartbeat.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 1[2mms[22m[39m

[2m Test Files [22m [1m[32m43 passed[39m[22m[90m (43)[39m
[2m      Tests [22m [1m[32m506 passed[39m[22m[90m (506)[39m
[2m   Start at [22m 09:42:24
[2m   Duration [22m 3.01s[2m (transform 3.07s, setup 4.59s, import 4.73s, tests 5.30s, environment 20.40s)[22m and \
> cooper@1.0.5 build
> npm run prebuild-info && electron-vite build


> cooper@1.0.5 prebuild-info
> node scripts/build-info.js

✓ Version updated to: 1.0.5+202604120642
✓ Build info written to: src/renderer/build-info.json
  - Branch: chore/sync-staging-and-main
  - Commit: f74ab60
vite v7.3.1 building ssr environment for production...
transforming...
✓ 363 modules transformed.
rendering chunks...
out/main/index.js  984.68 kB
✓ built in 610ms
vite v7.3.1 building ssr environment for production...
transforming...
✓ 2 modules transformed.
rendering chunks...
out/preload/index.js  26.87 kB
✓ built in 11ms
vite v7.3.1 building client environment for production...
transforming...
✓ 381 modules transformed.
rendering chunks...
../../out/renderer/index.html                                   1.08 kB
../../out/renderer/assets/lisa-head-Dee7yn_P.webp              11.46 kB
../../out/renderer/assets/ralph-head-2TYX3sxe.png             159.09 kB
../../out/renderer/assets/logo-BRU_mh-z.png                 1,111.86 kB
../../out/renderer/assets/index-Fa8ZM7on.css                   58.87 kB
../../out/renderer/assets/ReleaseNotesModal-ChOT4DLM.js         4.08 kB
../../out/renderer/assets/UpdateAvailableModal-B2rMt4tp.js      5.32 kB
../../out/renderer/assets/SessionHistory-DkycMs-3.js           25.23 kB
../../out/renderer/assets/FilePreviewModal-TvCXAXxs.js         34.70 kB
../../out/renderer/assets/SettingsModal-DSovQLmm.js            38.87 kB
../../out/renderer/assets/EnvironmentModal-BsZfujox.js         43.10 kB
../../out/renderer/assets/markdown-CgWcWLBA.js                383.96 kB
../../out/renderer/assets/index-CnS5QAJp.js                 1,337.94 kB
✓ built in 978ms passed during the sync work